### PR TITLE
Enhances filesystem API and adds file watching

### DIFF
--- a/.bruno/filesystem/List.bru
+++ b/.bruno/filesystem/List.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{URL}}/filesystem/~/
+  url: {{URL}}/filesystem/test
   body: none
   auth: none
 }

--- a/.bruno/filesystem/Tree GET.bru
+++ b/.bruno/filesystem/Tree GET.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Tree GET
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{URL}}/filesystem/tree
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Blaxel-Workspace: {{WORKSPACE}}
+}
+
+body:json {
+  {
+    "files": {
+      "test.txt": "hello wolrd"
+    }
+  }
+}

--- a/.bruno/filesystem/Tree.bru
+++ b/.bruno/filesystem/Tree.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Tree
+  type: http
+  seq: 5
+}
+
+put {
+  url: {{URL}}/filesystem/tree/test
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Blaxel-Workspace: {{WORKSPACE}}
+}
+
+body:json {
+  {
+    "files": {
+      "test.txt": "hello wolrd",
+      "test2/test.txt": "oula"
+    }
+  }
+}

--- a/.bruno/filesystem/Write binary.bru
+++ b/.bruno/filesystem/Write binary.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Write binary
+  type: http
+  seq: 7
+}
+
+put {
+  url: {{URL}}/filesystem/~/tmp/example.pdf
+  body: multipartForm
+  auth: none
+}
+
+headers {
+  X-Blaxel-Workspace: {{WORKSPACE}}
+}
+
+body:json {
+  {
+    "content": "#!/bin/bash\n\ncount=1\nwhile true; do\n  echo \"Iteration $count: Wow, we've looped $count times already! 🚀\"\n  sleep 5\n  ((count++))\ndone\n"
+  }
+}
+
+body:multipart-form {
+  file: @file(/Users/cploujoux/Documents/titre-propriete-corum.pdf)
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM --platform=linux/amd64 golang:1.23.3-bookworm as build
+FROM --platform=linux/amd64 node:22-alpine
 
 WORKDIR /blaxel/sandbox-api
 
-RUN go install github.com/air-verse/air@latest
+RUN apk update && apk add --no-cache \
+  git \
+  go \
+  && rm -rf /var/cache/apk/*
 
-EXPOSE 8080
 
 ENV HOME=/blaxel
+ENV GOBIN=/usr/local/bin
+ENV PATH=$PATH:$GOBIN
+
+RUN go install github.com/air-verse/air@latest
+EXPOSE 8080
 
 ENTRYPOINT ["air"]

--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -61,8 +61,7 @@ const docTemplate = `{
             "put": {
                 "description": "Create or update a file or directory",
                 "consumes": [
-                    "application/json",
-                    "multipart/form-data"
+                    "application/json"
                 ],
                 "produces": [
                     "application/json"
@@ -87,19 +86,6 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/FileRequest"
                         }
-                    },
-                    {
-                        "type": "file",
-                        "description": "File to upload",
-                        "name": "file",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "File permissions (octal format, e.g. 0644)",
-                        "name": "permissions",
-                        "in": "formData"
                     }
                 ],
                 "responses": {
@@ -594,6 +580,47 @@ const docTemplate = `{
                     },
                     "422": {
                         "description": "Unprocessable entity",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/watch/filesystem/{path}": {
+            "get": {
+                "description": "Streams the path of modified files (one per line) in the given directory. Closes when the client disconnects.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "filesystem"
+                ],
+                "summary": "Stream file modification events in a directory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Directory path to watch",
+                        "name": "path",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Stream of modified file paths, one per line",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid path",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -542,10 +542,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Process logs",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/ProcessLogs"
                         }
                     },
                     "404": {
@@ -800,6 +797,23 @@ const docTemplate = `{
                 "signal": {
                     "type": "string",
                     "example": "SIGTERM"
+                }
+            }
+        },
+        "ProcessLogs": {
+            "type": "object",
+            "properties": {
+                "logs": {
+                    "type": "string",
+                    "example": "logs output"
+                },
+                "stderr": {
+                    "type": "string",
+                    "example": "stderr output"
+                },
+                "stdout": {
+                    "type": "string",
+                    "example": "stdout output"
                 }
             }
         },

--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -666,6 +666,12 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "Ignore patterns (comma-separated)",
+                        "name": "ignore",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Directory path to watch",
                         "name": "path",
                         "in": "path",

--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -55,6 +55,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             },
@@ -106,6 +112,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             },
@@ -151,6 +163,12 @@ const docTemplate = `{
                     },
                     "422": {
                         "description": "Unprocessable entity",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -208,6 +226,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             },
@@ -248,6 +272,12 @@ const docTemplate = `{
                     },
                     "422": {
                         "description": "Unprocessable entity",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -293,6 +323,12 @@ const docTemplate = `{
                     },
                     "422": {
                         "description": "Unprocessable entity",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -363,6 +399,12 @@ const docTemplate = `{
                     },
                     "422": {
                         "description": "Unprocessable entity",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -446,6 +488,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -498,6 +546,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -542,6 +596,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -580,6 +640,12 @@ const docTemplate = `{
                     },
                     "422": {
                         "description": "Unprocessable entity",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -665,6 +731,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -721,6 +793,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/File"
                     }
                 },
+                "name": {
+                    "type": "string"
+                },
                 "path": {
                     "type": "string"
                 },
@@ -749,6 +824,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "lastModified": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 },
                 "owner": {
@@ -792,6 +870,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "lastModified": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 },
                 "owner": {
@@ -929,6 +1010,9 @@ const docTemplate = `{
         "Subdirectory": {
             "type": "object",
             "properties": {
+                "name": {
+                    "type": "string"
+                },
                 "path": {
                     "type": "string"
                 }

--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -50,8 +50,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -61,7 +61,8 @@ const docTemplate = `{
             "put": {
                 "description": "Create or update a file or directory",
                 "consumes": [
-                    "application/json"
+                    "application/json",
+                    "multipart/form-data"
                 ],
                 "produces": [
                     "application/json"
@@ -69,7 +70,7 @@ const docTemplate = `{
                 "tags": [
                     "filesystem"
                 ],
-                "summary": "Create or update file or directory",
+                "summary": "Create or update a file or directory",
                 "parameters": [
                     {
                         "type": "string",
@@ -79,13 +80,26 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "File or directory information",
+                        "description": "File or directory details",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/FileRequest"
                         }
+                    },
+                    {
+                        "type": "file",
+                        "description": "File to upload",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "File permissions (octal format, e.g. 0644)",
+                        "name": "permissions",
+                        "in": "formData"
                     }
                 ],
                 "responses": {
@@ -96,13 +110,13 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid request",
+                        "description": "Bad request",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -149,8 +163,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -203,8 +217,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -246,8 +260,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -291,8 +305,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -361,8 +375,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -441,8 +455,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -493,8 +507,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -540,8 +554,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -581,49 +595,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/watch/filesystem/{path}": {
-            "get": {
-                "description": "Streams the path of modified files (one per line) in the given directory. Closes when the client disconnects.",
-                "produces": [
-                    "text/plain"
-                ],
-                "tags": [
-                    "filesystem"
-                ],
-                "summary": "Stream file modification events in a directory",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Directory path to watch",
-                        "name": "path",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Stream of modified file paths, one per line",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid path",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -633,7 +606,7 @@ const docTemplate = `{
         },
         "/ws/process/{identifier}/logs/stream": {
             "get": {
-                "description": "Streams the stdout and stderr output of a process in real time as JSON messages. Closes when the process exits or the client disconnects.",
+                "description": "Streams the stdout and stderr output of a process in real time as JSON messages.",
                 "produces": [
                     "application/json"
                 ],
@@ -663,8 +636,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "500": {
-                        "description": "Internal server error",
+                    "422": {
+                        "description": "Unprocessable entity",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -897,6 +870,13 @@ const docTemplate = `{
                 },
                 "status": {
                     "type": "string",
+                    "enum": [
+                        "failed",
+                        "killed",
+                        "stopped",
+                        "running",
+                        "completed"
+                    ],
                     "example": "running"
                 },
                 "workingDir": {

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -86,19 +86,9 @@ paths:
             type: string
       requestBody:
         content:
-          multipart/form-data:
+          application/json:
             schema:
-              type: object
-              properties:
-                file:
-                  description: File to upload
-                  type: string
-                  format: binary
-                permissions:
-                  description: File permissions (octal format, e.g. 0644)
-                  type: string
-              required:
-                - file
+              $ref: "#/components/schemas/FileRequest"
         description: File or directory details
         required: true
       responses:
@@ -436,6 +426,39 @@ paths:
       summary: Stream process logs in real time
       tags:
         - process
+  "/watch/filesystem/{path}":
+    get:
+      description: Streams the path of modified files (one per line) in the given
+        directory. Closes when the client disconnects.
+      parameters:
+        - description: Directory path to watch
+          in: path
+          name: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Stream of modified file paths, one per line
+          content:
+            text/plain:
+              schema:
+                type: string
+        "400":
+          description: Invalid path
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      summary: Stream file modification events in a directory
+      tags:
+        - filesystem
   "/ws/process/{identifier}/logs/stream":
     get:
       description: Streams the stdout and stderr output of a process in real time as

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -33,8 +33,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
@@ -66,8 +66,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
@@ -86,10 +86,20 @@ paths:
             type: string
       requestBody:
         content:
-          application/json:
+          multipart/form-data:
             schema:
-              $ref: "#/components/schemas/FileRequest"
-        description: File or directory information
+              type: object
+              properties:
+                file:
+                  description: File to upload
+                  type: string
+                  format: binary
+                permissions:
+                  description: File permissions (octal format, e.g. 0644)
+                  type: string
+              required:
+                - file
+        description: File or directory details
         required: true
       responses:
         "200":
@@ -99,18 +109,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/SuccessResponse"
         "400":
-          description: Invalid request
+          description: Bad request
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-      summary: Create or update file or directory
+      summary: Create or update a file or directory
       tags:
         - filesystem
   "/network/process/{pid}/monitor":
@@ -137,8 +147,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
@@ -176,8 +186,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
@@ -209,8 +219,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
@@ -255,8 +265,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
@@ -287,8 +297,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
@@ -350,8 +360,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
@@ -384,8 +394,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
@@ -419,8 +429,8 @@ paths:
             text/plain:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             text/plain:
               schema:
@@ -428,43 +438,10 @@ paths:
       summary: Stream process logs in real time
       tags:
         - process
-  "/watch/filesystem/{path}":
-    get:
-      description: Streams the path of modified files (one per line) in the given
-        directory. Closes when the client disconnects.
-      parameters:
-        - description: Directory path to watch
-          in: path
-          name: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Stream of modified file paths, one per line
-          content:
-            text/plain:
-              schema:
-                type: string
-        "400":
-          description: Invalid path
-          content:
-            text/plain:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
-          content:
-            text/plain:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-      summary: Stream file modification events in a directory
-      tags:
-        - filesystem
   "/ws/process/{identifier}/logs/stream":
     get:
       description: Streams the stdout and stderr output of a process in real time as
-        JSON messages. Closes when the process exits or the client disconnects.
+        JSON messages.
       parameters:
         - description: Process identifier (PID or name)
           in: path
@@ -485,8 +462,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: Internal server error
+        "422":
+          description: Unprocessable entity
           content:
             application/json:
               schema:
@@ -656,6 +633,12 @@ components:
           example: Wed, 01 Jan 2023 12:00:00 GMT
           type: string
         status:
+          enum:
+            - failed
+            - killed
+            - stopped
+            - running
+            - completed
           example: running
           type: string
         workingDir:

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -385,9 +385,7 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties:
-                  type: string
-                type: object
+                $ref: "#/components/schemas/ProcessLogs"
         "404":
           description: Process not found
           content:
@@ -583,6 +581,18 @@ components:
       properties:
         signal:
           example: SIGTERM
+          type: string
+      type: object
+    ProcessLogs:
+      properties:
+        logs:
+          example: logs output
+          type: string
+        stderr:
+          example: stderr output
+          type: string
+        stdout:
+          example: stdout output
           type: string
       type: object
     ProcessRequest:

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -39,6 +39,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       summary: Delete file or directory
       tags:
         - filesystem
@@ -68,6 +74,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "422":
           description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -110,6 +122,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       summary: Create or update a file or directory
       tags:
         - filesystem
@@ -139,6 +157,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "422":
           description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -182,6 +206,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       summary: Start monitoring ports for a process
       tags:
         - network
@@ -211,6 +241,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "422":
           description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -261,6 +297,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       summary: Execute a command
       tags:
         - process
@@ -289,6 +331,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "422":
           description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -356,6 +404,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       summary: Kill a process
       tags:
         - process
@@ -384,6 +438,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "422":
           description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -419,6 +479,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "422":
           description: Unprocessable entity
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
           content:
             text/plain:
               schema:
@@ -489,6 +555,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       summary: Stream process logs in real time via WebSocket
       tags:
         - process
@@ -535,6 +607,8 @@ components:
           items:
             $ref: "#/components/schemas/File"
           type: array
+        name:
+          type: string
         path:
           type: string
         subdirectories:
@@ -554,6 +628,8 @@ components:
         group:
           type: string
         lastModified:
+          type: string
+        name:
           type: string
         owner:
           type: string
@@ -583,6 +659,8 @@ components:
         group:
           type: string
         lastModified:
+          type: string
+        name:
           type: string
         owner:
           type: string
@@ -680,6 +758,8 @@ components:
       type: object
     Subdirectory:
       properties:
+        name:
+          type: string
         path:
           type: string
       type: object

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -497,6 +497,11 @@ paths:
       description: Streams the path of modified files (one per line) in the given
         directory. Closes when the client disconnects.
       parameters:
+        - description: Ignore patterns (comma-separated)
+          in: query
+          name: ignore
+          schema:
+            type: string
         - description: Directory path to watch
           in: path
           name: path

--- a/sandbox-api/integration-tests/tests/filesystem/binary_test.go
+++ b/sandbox-api/integration-tests/tests/filesystem/binary_test.go
@@ -1,0 +1,81 @@
+package tests
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/blaxel-ai/sandbox-api/integration_tests/common"
+	"github.com/blaxel-ai/sandbox-api/src/handler"
+	"github.com/blaxel-ai/sandbox-api/src/handler/filesystem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBinaryFileUpload tests the binary file upload functionality
+func TestBinaryFileUpload(t *testing.T) {
+	t.Parallel()
+
+	// Create test binary file path with timestamp to avoid conflicts
+	timestamp := fmt.Sprintf("%d", time.Now().UnixNano())
+	testFilePath := fmt.Sprintf("/tmp/binary-file-%s.bin", timestamp)
+
+	// No need to create directory first - using /tmp directly
+	var successResp handler.SuccessResponse
+
+	// Create binary test data
+	binaryData := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0xFF, 0xFE, 0xFD, 0x8A, 0x8B, 0x8C}
+
+	// Test binary file upload
+	resp, err := common.MakeMultipartRequest(
+		http.MethodPut,
+		"/filesystem"+testFilePath,
+		binaryData,
+		"test-binary.bin",
+		map[string]string{
+			"permissions": "0644",
+			"path":        testFilePath,
+		},
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Verify response
+	body, _ := io.ReadAll(resp.Body)
+	t.Logf("Response body: %s", string(body))
+	t.Logf("Status code: %d", resp.StatusCode)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Reset the response body for JSON parsing
+	resp.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	err = common.ParseJSONResponse(resp, &successResp)
+	require.NoError(t, err)
+	assert.Contains(t, successResp.Message, "success")
+
+	// Verify the file exists by requesting it
+	var fileResponse filesystem.FileWithContent
+	resp, err = common.MakeRequestAndParse(http.MethodGet, "/filesystem"+testFilePath, nil, &fileResponse)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, testFilePath, fileResponse.Path)
+
+	// Binary content might be transformed in the JSON response due to encoding issues
+	// Instead, check that we got some content back and the file size is at least as expected
+	t.Logf("Expected %d bytes, got %d bytes", len(binaryData), len(fileResponse.Content))
+	assert.Greater(t, len(fileResponse.Content), 0, "File content should not be empty")
+	assert.Equal(t, int64(len(binaryData)), fileResponse.Size, "File size should match our uploaded data")
+
+	// Clean up - delete the file
+	resp, err = common.MakeRequestAndParse(http.MethodDelete, "/filesystem"+testFilePath, nil, &successResp)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, successResp.Message, "success")
+}

--- a/sandbox-api/integration-tests/tests/process/process_test.go
+++ b/sandbox-api/integration-tests/tests/process/process_test.go
@@ -234,11 +234,13 @@ func TestProcessOutputByName(t *testing.T) {
 	err = json.NewDecoder(resp.Body).Decode(&outputResponse)
 	require.NoError(t, err)
 
+	require.Contains(t, outputResponse, "logs")
 	require.Contains(t, outputResponse, "stdout")
 	require.Contains(t, outputResponse, "stderr")
 
 	assert.Equal(t, "test output\n", outputResponse["stdout"])
 	assert.Equal(t, "test error\n", outputResponse["stderr"])
+	assert.Equal(t, "test output\ntest error\n", outputResponse["logs"])
 }
 
 func TestProcessStreamLogs(t *testing.T) {

--- a/sandbox-api/src/api/router.go
+++ b/sandbox-api/src/api/router.go
@@ -72,9 +72,12 @@ func SetupRouter() *gin.Engine {
 				fsHandler.HandleCreateOrUpdateTree(c)
 				c.Abort()
 				return
+			} else if method == "DELETE" {
+				fsHandler.HandleDeleteTree(c)
+				c.Abort()
+				return
 			}
 		}
-
 		c.Next()
 	})
 

--- a/sandbox-api/src/handler/base.go
+++ b/sandbox-api/src/handler/base.go
@@ -42,6 +42,13 @@ func (h *BaseHandler) SendSuccess(c *gin.Context, message string) {
 	})
 }
 
+func (h *BaseHandler) SendSuccessWithPath(c *gin.Context, path string, message string) {
+	c.JSON(http.StatusOK, SuccessResponse{
+		Path:    path,
+		Message: message,
+	})
+}
+
 // SendJSON sends a JSON response with the given status code
 func (h *BaseHandler) SendJSON(c *gin.Context, status int, data interface{}) {
 	c.JSON(status, data)

--- a/sandbox-api/src/handler/constants/process.go
+++ b/sandbox-api/src/handler/constants/process.go
@@ -1,10 +1,12 @@
 package constants
 
+type ProcessStatus string
+
 // Process status constants
 const (
-	ProcessStatusFailed    = "failed"
-	ProcessStatusKilled    = "killed"
-	ProcessStatusStopped   = "stopped"
-	ProcessStatusRunning   = "running"
-	ProcessStatusCompleted = "completed"
+	ProcessStatusFailed    ProcessStatus = "failed"
+	ProcessStatusKilled    ProcessStatus = "killed"
+	ProcessStatusStopped   ProcessStatus = "stopped"
+	ProcessStatusRunning   ProcessStatus = "running"
+	ProcessStatusCompleted ProcessStatus = "completed"
 )

--- a/sandbox-api/src/handler/constants/process.go
+++ b/sandbox-api/src/handler/constants/process.go
@@ -1,0 +1,10 @@
+package constants
+
+// Process status constants
+const (
+	ProcessStatusFailed    = "failed"
+	ProcessStatusKilled    = "killed"
+	ProcessStatusStopped   = "stopped"
+	ProcessStatusRunning   = "running"
+	ProcessStatusCompleted = "completed"
+)

--- a/sandbox-api/src/handler/filesystem.go
+++ b/sandbox-api/src/handler/filesystem.go
@@ -524,6 +524,7 @@ func (h *FileSystemHandler) HandleDeleteTree(c *gin.Context) {
 // @Description Streams the path of modified files (one per line) in the given directory. Closes when the client disconnects.
 // @Tags filesystem
 // @Produce plain
+// @Param ignore query string false "Ignore patterns (comma-separated)"
 // @Param path path string true "Directory path to watch"
 // @Success 200 {string} string "Stream of modified file paths, one per line"
 // @Failure 400 {object} ErrorResponse "Invalid path"

--- a/sandbox-api/src/handler/filesystem/directory.go
+++ b/sandbox-api/src/handler/filesystem/directory.go
@@ -11,11 +11,13 @@ import (
 // Subdirectory represents a subdirectory in the filesystem
 type Subdirectory struct {
 	Path string `json:"path"`
+	Name string `json:"name"`
 } // @name Subdirectory
 
 // Directory represents a directory in the filesystem
 type Directory struct {
 	Path           string          `json:"path"`
+	Name           string          `json:"name"`
 	Files          []*File         `json:"files"`
 	Subdirectories []*Subdirectory `json:"subdirectories"` // @name Subdirectories
 } // @name Directory
@@ -23,6 +25,7 @@ type Directory struct {
 func NewDirectory(path string) *Directory {
 	return &Directory{
 		Path:           path,
+		Name:           filepath.Base(path),
 		Files:          []*File{},
 		Subdirectories: []*Subdirectory{},
 	}

--- a/sandbox-api/src/handler/filesystem/directory.go
+++ b/sandbox-api/src/handler/filesystem/directory.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/fsnotify/fsnotify"
@@ -143,6 +144,71 @@ func (fs *Filesystem) WatchDirectory(path string, callback func(event fsnotify.E
 				if (event.Op&fsnotify.Remove != 0 || event.Op&fsnotify.Rename != 0) && event.Name == absPath {
 					return
 				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				fmt.Println("error:", err)
+			}
+		}
+	}()
+
+	stop := func() {
+		close(stopChan)
+		watcher.Close()
+	}
+	return stop, nil
+}
+
+// WatchDirectoryRecursive watches a directory and all its subdirectories for changes.
+// The callback is called with the event when a change occurs.
+func (fs *Filesystem) WatchDirectoryRecursive(path string, callback func(event fsnotify.Event)) (func(), error) {
+	absPath, err := fs.GetAbsolutePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	// Helper to add all subdirectories
+	addDirs := func(root string) error {
+		return filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return watcher.Add(p)
+			}
+			return nil
+		})
+	}
+
+	if err := addDirs(absPath); err != nil {
+		watcher.Close()
+		return nil, err
+	}
+
+	stopChan := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				callback(event)
+				// If a new directory is created, add it (and its subdirs)
+				if event.Op&fsnotify.Create != 0 {
+					info, err := os.Stat(event.Name)
+					if err == nil && info.IsDir() {
+						_ = addDirs(event.Name)
+					}
+				}
+				// If a directory is removed, watcher will error on it, but fsnotify cleans up
 			case err, ok := <-watcher.Errors:
 				if !ok {
 					return

--- a/sandbox-api/src/handler/filesystem/directory_test.go
+++ b/sandbox-api/src/handler/filesystem/directory_test.go
@@ -35,7 +35,7 @@ func TestDirectoryMethods(t *testing.T) {
 	}
 
 	// Test adding and getting subdirectories
-	subdir := &Subdirectory{Path: "test/subdir"}
+	subdir := &Subdirectory{Path: "test/subdir", Name: "subdir"}
 	dir.AddSubdirectory(subdir)
 
 	if dir.CountSubdirectories() != 1 {

--- a/sandbox-api/src/handler/filesystem/filesystem.go
+++ b/sandbox-api/src/handler/filesystem/filesystem.go
@@ -31,6 +31,7 @@ type FileByte struct {
 // File is a data transfer object for File with string permissions
 type File struct {
 	Path         string    `json:"path"`
+	Name         string    `json:"name"`
 	Permissions  string    `json:"permissions"`
 	Size         int64     `json:"size"`
 	LastModified time.Time `json:"lastModified"`
@@ -316,7 +317,7 @@ func (fs *Filesystem) ListDirectory(path string) (*Directory, error) {
 		}
 
 		if entry.IsDir() {
-			dir.AddSubdirectory(&Subdirectory{Path: entryPath})
+			dir.AddSubdirectory(&Subdirectory{Path: entryPath, Name: entry.Name()})
 		} else {
 			// It's a file
 			owner, group, err := fs.getFileOwnerAndGroup(absEntryPath)
@@ -324,7 +325,7 @@ func (fs *Filesystem) ListDirectory(path string) (*Directory, error) {
 				return nil, err
 			}
 
-			file := &File{Path: entryPath, Permissions: fmt.Sprintf("%o", info.Mode()), Size: info.Size(), LastModified: info.ModTime(), Owner: owner, Group: group}
+			file := &File{Path: entryPath, Name: entry.Name(), Permissions: fmt.Sprintf("%o", info.Mode()), Size: info.Size(), LastModified: info.ModTime(), Owner: owner, Group: group}
 			dir.AddFile(file)
 		}
 	}

--- a/sandbox-api/src/handler/network.go
+++ b/sandbox-api/src/handler/network.go
@@ -57,6 +57,7 @@ func (h *NetworkHandler) UnregisterPortOpenCallback(pid int) {
 // @Success 200 {object} map[string]interface{} "Object containing PID and array of network.PortInfo"
 // @Failure 400 {object} ErrorResponse "Invalid process ID"
 // @Failure 422 {object} ErrorResponse "Unprocessable entity"
+// @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /network/process/{pid}/ports [get]
 func (h *NetworkHandler) HandleGetPorts(c *gin.Context) {
 	pidStr, err := h.GetPathParam(c, "pid")
@@ -94,6 +95,7 @@ func (h *NetworkHandler) HandleGetPorts(c *gin.Context) {
 // @Success 200 {object} map[string]interface{} "Object containing PID and success message"
 // @Failure 400 {object} ErrorResponse "Invalid request"
 // @Failure 422 {object} ErrorResponse "Unprocessable entity"
+// @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /network/process/{pid}/monitor [post]
 func (h *NetworkHandler) HandleMonitorPorts(c *gin.Context) {
 	pidStr, err := h.GetPathParam(c, "pid")
@@ -147,6 +149,7 @@ func (h *NetworkHandler) HandleMonitorPorts(c *gin.Context) {
 // @Success 200 {object} map[string]interface{} "Object containing PID and success message"
 // @Failure 400 {object} ErrorResponse "Invalid process ID"
 // @Failure 422 {object} ErrorResponse "Unprocessable entity"
+// @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /network/process/{pid}/monitor [delete]
 func (h *NetworkHandler) HandleStopMonitoringPorts(c *gin.Context) {
 	pidStr, err := h.GetPathParam(c, "pid")

--- a/sandbox-api/src/handler/network.go
+++ b/sandbox-api/src/handler/network.go
@@ -56,7 +56,7 @@ func (h *NetworkHandler) UnregisterPortOpenCallback(pid int) {
 // @Param pid path int true "Process ID"
 // @Success 200 {object} map[string]interface{} "Object containing PID and array of network.PortInfo"
 // @Failure 400 {object} ErrorResponse "Invalid process ID"
-// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Failure 422 {object} ErrorResponse "Unprocessable entity"
 // @Router /network/process/{pid}/ports [get]
 func (h *NetworkHandler) HandleGetPorts(c *gin.Context) {
 	pidStr, err := h.GetPathParam(c, "pid")
@@ -73,7 +73,7 @@ func (h *NetworkHandler) HandleGetPorts(c *gin.Context) {
 
 	ports, err := h.GetPortsForPID(pid)
 	if err != nil {
-		h.SendError(c, http.StatusInternalServerError, err)
+		h.SendError(c, http.StatusUnprocessableEntity, err)
 		return
 	}
 
@@ -93,7 +93,7 @@ func (h *NetworkHandler) HandleGetPorts(c *gin.Context) {
 // @Param request body PortMonitorRequest true "Port monitor configuration"
 // @Success 200 {object} map[string]interface{} "Object containing PID and success message"
 // @Failure 400 {object} ErrorResponse "Invalid request"
-// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Failure 422 {object} ErrorResponse "Unprocessable entity"
 // @Router /network/process/{pid}/monitor [post]
 func (h *NetworkHandler) HandleMonitorPorts(c *gin.Context) {
 	pidStr, err := h.GetPathParam(c, "pid")
@@ -146,7 +146,7 @@ func (h *NetworkHandler) HandleMonitorPorts(c *gin.Context) {
 // @Param pid path int true "Process ID"
 // @Success 200 {object} map[string]interface{} "Object containing PID and success message"
 // @Failure 400 {object} ErrorResponse "Invalid process ID"
-// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Failure 422 {object} ErrorResponse "Unprocessable entity"
 // @Router /network/process/{pid}/monitor [delete]
 func (h *NetworkHandler) HandleStopMonitoringPorts(c *gin.Context) {
 	pidStr, err := h.GetPathParam(c, "pid")

--- a/sandbox-api/src/handler/process.go
+++ b/sandbox-api/src/handler/process.go
@@ -188,6 +188,7 @@ func (h *ProcessHandler) HandleListProcesses(c *gin.Context) {
 // @Success 200 {object} ProcessResponse "Process information"
 // @Failure 400 {object} ErrorResponse "Invalid request"
 // @Failure 422 {object} ErrorResponse "Unprocessable entity"
+// @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /process [post]
 func (h *ProcessHandler) HandleExecuteCommand(c *gin.Context) {
 	var req ProcessRequest
@@ -234,6 +235,7 @@ func (h *ProcessHandler) HandleExecuteCommand(c *gin.Context) {
 // @Success 200 {object} process.ProcessLogs "Process logs"
 // @Failure 404 {object} ErrorResponse "Process not found"
 // @Failure 422 {object} ErrorResponse "Unprocessable entity"
+// @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /process/{identifier}/logs [get]
 func (h *ProcessHandler) HandleGetProcessLogs(c *gin.Context) {
 	identifier, err := h.GetPathParam(c, "identifier")
@@ -260,6 +262,7 @@ func (h *ProcessHandler) HandleGetProcessLogs(c *gin.Context) {
 // @Success 200 {string} string "Stream of process logs, one line per log (prefixed with stdout:/stderr:)"
 // @Failure 404 {object} ErrorResponse "Process not found"
 // @Failure 422 {object} ErrorResponse "Unprocessable entity"
+// @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /process/{identifier}/logs/stream [get]
 func (h *ProcessHandler) HandleGetProcessLogsStream(c *gin.Context) {
 	identifier, err := h.GetPathParam(c, "identifier")
@@ -313,6 +316,7 @@ func (h *ProcessHandler) HandleGetProcessLogsStream(c *gin.Context) {
 // @Success 200 {object} SuccessResponse "Process stopped"
 // @Failure 404 {object} ErrorResponse "Process not found"
 // @Failure 422 {object} ErrorResponse "Unprocessable entity"
+// @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /process/{identifier} [delete]
 func (h *ProcessHandler) HandleStopProcess(c *gin.Context) {
 	identifier, err := h.GetPathParam(c, "identifier")
@@ -341,6 +345,7 @@ func (h *ProcessHandler) HandleStopProcess(c *gin.Context) {
 // @Success 200 {object} SuccessResponse "Process killed"
 // @Failure 404 {object} ErrorResponse "Process not found"
 // @Failure 422 {object} ErrorResponse "Unprocessable entity"
+// @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /process/{identifier}/kill [delete]
 func (h *ProcessHandler) HandleKillProcess(c *gin.Context) {
 	identifier, err := h.GetPathParam(c, "identifier")
@@ -453,6 +458,7 @@ func (w *wsWriter) Write(data []byte) (int, error) {
 // @Success 101 {string} string "WebSocket connection established"
 // @Failure 404 {object} ErrorResponse "Process not found"
 // @Failure 422 {object} ErrorResponse "Unprocessable entity"
+// @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /ws/process/{identifier}/logs/stream [get]
 func (h *ProcessHandler) HandleGetProcessLogsStreamWebSocket(c *gin.Context) {
 	identifier, err := h.GetPathParam(c, "identifier")

--- a/sandbox-api/src/handler/process.go
+++ b/sandbox-api/src/handler/process.go
@@ -86,7 +86,7 @@ func (h *ProcessHandler) ExecuteProcess(command string, workingDir string, name 
 		PID:         processInfo.PID,
 		Name:        processInfo.Name,
 		Command:     processInfo.Command,
-		Status:      processInfo.Status,
+		Status:      string(processInfo.Status),
 		StartedAt:   processInfo.StartedAt.Format("Mon, 02 Jan 2006 15:04:05 GMT"),
 		CompletedAt: completedAt,
 		ExitCode:    processInfo.ExitCode,
@@ -107,7 +107,7 @@ func (h *ProcessHandler) ListProcesses() []ProcessResponse {
 			PID:         p.PID,
 			Name:        p.Name,
 			Command:     p.Command,
-			Status:      p.Status,
+			Status:      string(p.Status),
 			StartedAt:   p.StartedAt.Format("Mon, 02 Jan 2006 15:04:05 GMT"),
 			CompletedAt: completedAt,
 			ExitCode:    p.ExitCode,
@@ -132,7 +132,7 @@ func (h *ProcessHandler) GetProcess(identifier string) (ProcessResponse, error) 
 		PID:         processInfo.PID,
 		Name:        processInfo.Name,
 		Command:     processInfo.Command,
-		Status:      processInfo.Status,
+		Status:      string(processInfo.Status),
 		StartedAt:   processInfo.StartedAt.Format("Mon, 02 Jan 2006 15:04:05 GMT"),
 		CompletedAt: completedAt,
 		ExitCode:    processInfo.ExitCode,
@@ -209,7 +209,7 @@ func (h *ProcessHandler) HandleExecuteCommand(c *gin.Context) {
 	// If a name is provided, check if a process with that name already exists
 	if req.Name != "" {
 		alreadyExists, err := GetProcessHandler().GetProcess(req.Name)
-		if err == nil && alreadyExists.Status == constants.ProcessStatusRunning {
+		if err == nil && alreadyExists.Status == string(constants.ProcessStatusRunning) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("process with name '%s' already exists and is running", req.Name)})
 			return
 		}

--- a/sandbox-api/src/handler/process.go
+++ b/sandbox-api/src/handler/process.go
@@ -141,7 +141,7 @@ func (h *ProcessHandler) GetProcess(identifier string) (ProcessResponse, error) 
 }
 
 // GetProcessOutput gets the output of a process
-func (h *ProcessHandler) GetProcessOutput(identifier string) (string, string, error) {
+func (h *ProcessHandler) GetProcessOutput(identifier string) (process.ProcessLogs, error) {
 	return h.processManager.GetProcessOutput(identifier)
 }
 
@@ -231,7 +231,7 @@ func (h *ProcessHandler) HandleExecuteCommand(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param identifier path string true "Process identifier (PID or name)"
-// @Success 200 {object} map[string]string "Process logs"
+// @Success 200 {object} process.ProcessLogs "Process logs"
 // @Failure 404 {object} ErrorResponse "Process not found"
 // @Failure 422 {object} ErrorResponse "Unprocessable entity"
 // @Router /process/{identifier}/logs [get]
@@ -242,16 +242,13 @@ func (h *ProcessHandler) HandleGetProcessLogs(c *gin.Context) {
 		return
 	}
 
-	stdout, stderr, err := h.GetProcessOutput(identifier)
+	logs, err := h.GetProcessOutput(identifier)
 	if err != nil {
 		h.SendError(c, http.StatusNotFound, err)
 		return
 	}
 
-	h.SendJSON(c, http.StatusOK, gin.H{
-		"stdout": stdout,
-		"stderr": stderr,
-	})
+	h.SendJSON(c, http.StatusOK, logs)
 }
 
 // HandleGetProcessLogsStream handles GET requests to /process/{identifier}/logs/stream

--- a/sandbox-api/src/handler/process/process.go
+++ b/sandbox-api/src/handler/process/process.go
@@ -38,15 +38,15 @@ type ProcessLogs struct {
 
 // ProcessInfo stores information about a running process
 type ProcessInfo struct {
-	PID         string     `json:"pid"`
-	Name        string     `json:"name"`
-	Command     string     `json:"command"`
-	Cmd         *exec.Cmd  `json:"cmd"`
-	StartedAt   time.Time  `json:"startedAt"`
-	CompletedAt *time.Time `json:"completedAt"`
-	ExitCode    int        `json:"exitCode"`
-	Status      string     `json:"status"`
-	WorkingDir  string     `json:"workingDir"`
+	PID         string                  `json:"pid"`
+	Name        string                  `json:"name"`
+	Command     string                  `json:"command"`
+	Cmd         *exec.Cmd               `json:"cmd"`
+	StartedAt   time.Time               `json:"startedAt"`
+	CompletedAt *time.Time              `json:"completedAt"`
+	ExitCode    int                     `json:"exitCode"`
+	Status      constants.ProcessStatus `json:"status"`
+	WorkingDir  string                  `json:"workingDir"`
 	stdout      *strings.Builder
 	stderr      *strings.Builder
 	logs        *strings.Builder

--- a/sandbox-api/src/handler/process/process_test.go
+++ b/sandbox-api/src/handler/process/process_test.go
@@ -74,17 +74,17 @@ func TestProcessManagerIntegrationWithPID(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// Get and verify output
-		stdout, stderr, err := pm.GetProcessOutput(echoPID)
+		logs, err := pm.GetProcessOutput(echoPID)
 		if err != nil {
 			t.Fatalf("Error getting echo process output: %v", err)
 		}
 
-		if strings.TrimSpace(stdout) != expectedOutput {
-			t.Errorf("Expected stdout to be '%s', got: '%s'", expectedOutput, strings.TrimSpace(stdout))
+		if strings.TrimSpace(logs.Stdout) != expectedOutput {
+			t.Errorf("Expected stdout to be '%s', got: '%s'", expectedOutput, strings.TrimSpace(logs.Stdout))
 		}
 
-		if stderr != "" {
-			t.Errorf("Expected stderr to be empty, got: '%s'", stderr)
+		if logs.Stderr != "" {
+			t.Errorf("Expected stderr to be empty, got: '%s'", logs.Stderr)
 		}
 
 		// Verify process completed successfully
@@ -114,23 +114,23 @@ func TestProcessManagerIntegrationWithPID(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// Get and verify output
-		stdout, stderr, err := pm.GetProcessOutput(lsPID)
+		logs, err := pm.GetProcessOutput(lsPID)
 		if err != nil {
 			t.Fatalf("Error getting ls process output: %v", err)
 		}
 
 		// Verify that we get some output from listing /tmp
-		if stdout == "" {
+		if logs.Stdout == "" {
 			t.Error("Expected stdout to contain directory listing, got empty string")
 		}
 
 		// Check if common tmp folder entries are in the output
-		if !strings.Contains(stdout, "total") {
-			t.Errorf("Expected ls -la output to contain 'total', output: %s", stdout)
+		if !strings.Contains(logs.Stdout, "total") {
+			t.Errorf("Expected ls -la output to contain 'total', output: %s", logs.Stdout)
 		}
 
-		if stderr != "" {
-			t.Errorf("Expected stderr to be empty, got: '%s'", stderr)
+		if logs.Stderr != "" {
+			t.Errorf("Expected stderr to be empty, got: '%s'", logs.Stderr)
 		}
 
 		// Verify process completed successfully
@@ -247,17 +247,17 @@ func TestProcessManagerIntegrationWithName(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// Get and verify output
-		stdout, stderr, err := pm.GetProcessOutput(name)
+		logs, err := pm.GetProcessOutput(name)
 		if err != nil {
 			t.Fatalf("Error getting echo process output: %v", err)
 		}
 
-		if strings.TrimSpace(stdout) != expectedOutput {
-			t.Errorf("Expected stdout to be '%s', got: '%s'", expectedOutput, strings.TrimSpace(stdout))
+		if strings.TrimSpace(logs.Stdout) != expectedOutput {
+			t.Errorf("Expected stdout to be '%s', got: '%s'", expectedOutput, strings.TrimSpace(logs.Stdout))
 		}
 
-		if stderr != "" {
-			t.Errorf("Expected stderr to be empty, got: '%s'", stderr)
+		if logs.Stderr != "" {
+			t.Errorf("Expected stderr to be empty, got: '%s'", logs.Stderr)
 		}
 
 		// Verify process completed successfully
@@ -288,23 +288,23 @@ func TestProcessManagerIntegrationWithName(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// Get and verify output
-		stdout, stderr, err := pm.GetProcessOutput(name)
+		logs, err := pm.GetProcessOutput(name)
 		if err != nil {
 			t.Fatalf("Error getting ls process output: %v", err)
 		}
 
 		// Verify that we get some output from listing /tmp
-		if stdout == "" {
+		if logs.Stdout == "" {
 			t.Error("Expected stdout to contain directory listing, got empty string")
 		}
 
 		// Check if common tmp folder entries are in the output
-		if !strings.Contains(stdout, "total") {
-			t.Errorf("Expected ls -la output to contain 'total', output: %s", stdout)
+		if !strings.Contains(logs.Stdout, "total") {
+			t.Errorf("Expected ls -la output to contain 'total', output: %s", logs.Stdout)
 		}
 
-		if stderr != "" {
-			t.Errorf("Expected stderr to be empty, got: '%s'", stderr)
+		if logs.Stderr != "" {
+			t.Errorf("Expected stderr to be empty, got: '%s'", logs.Stderr)
 		}
 
 		// Verify process completed successfully

--- a/sandbox-api/src/mcp/process.go
+++ b/sandbox-api/src/mcp/process.go
@@ -45,17 +45,11 @@ func (s *Server) registerProcessTools() error {
 	// Get process logs
 	if err := s.mcpServer.RegisterTool("processGetLogs", "Get logs for a specific process",
 		func(args ProcessIdentifierArgs) (*mcp_golang.ToolResponse, error) {
-			stdout, stderr, err := s.handlers.Process.GetProcessOutput(args.Identifier)
+			logs, err := s.handlers.Process.GetProcessOutput(args.Identifier)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get process output: %w", err)
 			}
-
-			response := map[string]interface{}{
-				"stdout": stdout,
-				"stderr": stderr,
-			}
-
-			return CreateJSONResponse(response)
+			return CreateJSONResponse(logs)
 		}); err != nil {
 		return fmt.Errorf("failed to register getProcessLogs tool: %w", err)
 	}


### PR DESCRIPTION
This pull request improves the filesystem API by:

- Refactoring the API for tree structure management.
- Adding a file watching endpoint to monitor file system events.
- Supports binary file uploads via multipart forms.
- Improves API definitions by standardizing response formats and removing unnecessary 500 errors, replacing them with 422 errors where appropriate.
- Unifies process logs by combining stdout and stderr into a single log stream.