### PR TITLE
Adds Next.js application scaffolding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV GOBIN=/usr/local/bin
 ENV PATH=$PATH:$GOBIN
 
 RUN go install github.com/air-verse/air@latest
+RUN npx create-next-app@latest /blaxel/app --use-npm --typescript --eslint --tailwind --src-dir --app --import-alias "@/*" --no-git --yes --no-turbopack
 EXPOSE 8080
 
 ENTRYPOINT ["air"]


### PR DESCRIPTION
Sets up a basic Next.js application within the Docker image to provide a foundation for the frontend.
The scaffolding includes TypeScript, ESLint, Tailwind CSS, the app directory, a source directory, import aliases, and disables Git initialization and Turbopack to streamline the initial setup.
