### PR TITLE
Encodes filesystem paths for API requests

### DIFF
--- a/sandbox-api/integration-tests/common/request.go
+++ b/sandbox-api/integration-tests/common/request.go
@@ -160,3 +160,50 @@ func WaitForAPI(maxRetries int, retryDelay time.Duration) error {
 
 	return fmt.Errorf("API did not become ready in time")
 }
+
+// EncodeFilesystemPath encodes a path for the filesystem API
+// Absolute paths (starting with /) need to have the leading slash URL-encoded as %2F
+// Relative paths are used as-is
+func EncodeFilesystemPath(path string) string {
+	if path == "" {
+		return "/filesystem/"
+	}
+
+	if path[0] == '/' {
+		// For absolute paths, encode only the leading slash to indicate absolute path
+		// The rest of the path remains as-is
+		return "/filesystem%2F" + path[1:]
+	}
+	// For relative paths, just append to /filesystem/
+	return "/filesystem/" + path
+}
+
+// EncodeWatchPath encodes a path for the watch filesystem API
+// Similar to EncodeFilesystemPath but for /watch/filesystem endpoint
+func EncodeWatchPath(path string) string {
+	if path == "" {
+		return "/watch/filesystem/"
+	}
+
+	if path[0] == '/' {
+		// For absolute paths, encode only the leading slash to indicate absolute path
+		return "/watch/filesystem%2F" + path[1:]
+	}
+	// For relative paths, just append to /watch/filesystem/
+	return "/watch/filesystem/" + path
+}
+
+// EncodeTreePath encodes a path for the tree filesystem API
+// Similar to EncodeFilesystemPath but for /filesystem/tree endpoint
+func EncodeTreePath(path string) string {
+	if path == "" {
+		return "/filesystem/tree/"
+	}
+
+	if path[0] == '/' {
+		// For absolute paths, encode only the leading slash to indicate absolute path
+		return "/filesystem/tree%2F" + path[1:]
+	}
+	// For relative paths, just append to /filesystem/tree/
+	return "/filesystem/tree/" + path
+}

--- a/sandbox-api/integration-tests/tests/filesystem/binary_test.go
+++ b/sandbox-api/integration-tests/tests/filesystem/binary_test.go
@@ -32,7 +32,7 @@ func TestBinaryFileUpload(t *testing.T) {
 	// Test binary file upload
 	resp, err := common.MakeMultipartRequest(
 		http.MethodPut,
-		"/filesystem"+testFilePath,
+		common.EncodeFilesystemPath(testFilePath),
 		binaryData,
 		"test-binary.bin",
 		map[string]string{
@@ -59,7 +59,7 @@ func TestBinaryFileUpload(t *testing.T) {
 
 	// Verify the file exists by requesting it
 	var fileResponse filesystem.FileWithContent
-	resp, err = common.MakeRequestAndParse(http.MethodGet, "/filesystem"+testFilePath, nil, &fileResponse)
+	resp, err = common.MakeRequestAndParse(http.MethodGet, common.EncodeFilesystemPath(testFilePath), nil, &fileResponse)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -73,7 +73,7 @@ func TestBinaryFileUpload(t *testing.T) {
 	assert.Equal(t, int64(len(binaryData)), fileResponse.Size, "File size should match our uploaded data")
 
 	// Clean up - delete the file
-	resp, err = common.MakeRequestAndParse(http.MethodDelete, "/filesystem"+testFilePath, nil, &successResp)
+	resp, err = common.MakeRequestAndParse(http.MethodDelete, common.EncodeFilesystemPath(testFilePath), nil, &successResp)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/sandbox-api/integration-tests/tests/process/process_test.go
+++ b/sandbox-api/integration-tests/tests/process/process_test.go
@@ -4,15 +4,12 @@ import (
 	"bufio"
 	"encoding/json"
 	"net/http"
-	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/blaxel-ai/sandbox-api/integration_tests/common"
-	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -372,74 +369,6 @@ collectLoop:
 		}
 	}
 	assert.GreaterOrEqual(t, count, 5, "should receive at least 5 tick lines from stream")
-}
-
-func TestProcessStreamLogsWebSocket(t *testing.T) {
-	// Start a process that outputs several lines
-	processRequest := map[string]interface{}{
-		"command": "for i in $(seq 1 5); do echo wslog $i; sleep 0.05; done",
-		"cwd":     "/",
-	}
-
-	resp, err := common.MakeRequest(http.MethodPost, "/process", processRequest)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	var processResponse map[string]interface{}
-	err = json.NewDecoder(resp.Body).Decode(&processResponse)
-	require.NoError(t, err)
-
-	processName, ok := processResponse["name"].(string)
-	require.True(t, ok)
-
-	// Build ws:// URL from API base URL
-	apiBase := os.Getenv("API_BASE_URL")
-	if apiBase == "" {
-		apiBase = "http://localhost:8080"
-	}
-	u, err := url.Parse(apiBase)
-	require.NoError(t, err)
-	u.Scheme = "ws"
-	u.Path = "/ws/process/" + processName + "/logs/stream"
-
-	ws, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
-	require.NoError(t, err)
-	defer ws.Close()
-
-	logLines := []string{}
-	done := make(chan struct{})
-	go func() {
-		for {
-			_, msg, err := ws.ReadMessage()
-			if err != nil {
-				close(done)
-				return
-			}
-			var payload map[string]interface{}
-			err = json.Unmarshal(msg, &payload)
-			if err == nil {
-				if logVal, ok := payload["log"].(string); ok {
-					logLines = append(logLines, logVal)
-				}
-			}
-		}
-	}()
-
-	// Wait for logs or timeout
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-	}
-
-	count := 0
-	for _, line := range logLines {
-		if strings.Contains(line, "wslog") {
-			count++
-		}
-	}
-	assert.GreaterOrEqual(t, count, 5, "should receive at least 5 wslog lines from websocket stream")
 }
 
 func TestProcessKillWithChildProcesses(t *testing.T) {

--- a/sandbox-api/src/api/router.go
+++ b/sandbox-api/src/api/router.go
@@ -115,10 +115,6 @@ func SetupRouter() *gin.Engine {
 	r.POST("/network/process/:pid/monitor", networkHandler.HandleMonitorPorts)
 	r.DELETE("/network/process/:pid/monitor", networkHandler.HandleStopMonitoringPorts)
 
-	// Register WebSocket endpoints for watch and logs stream
-	r.GET("/ws/watch/filesystem/*path", fsHandler.HandleWatchDirectoryWebSocket)
-	r.GET("/ws/process/:identifier/logs/stream", processHandler.HandleGetProcessLogsStreamWebSocket)
-
 	// Health check route
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok"})

--- a/sandbox-api/src/handler/filesystem.go
+++ b/sandbox-api/src/handler/filesystem.go
@@ -9,12 +9,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/websocket"
 	"github.com/sirupsen/logrus"
 
 	"github.com/blaxel-ai/sandbox-api/src/handler/filesystem"
@@ -44,15 +42,56 @@ type FileRequest struct {
 
 // NewFileSystemHandler creates a new filesystem handler
 func NewFileSystemHandler() *FileSystemHandler {
+	// Get working directory from environment or use default
+	workingDir := os.Getenv("WORKDIR")
+	if workingDir == "" {
+		// Try to get current working directory
+		if cwd, err := os.Getwd(); err == nil {
+			workingDir = cwd
+		} else {
+			// Default to /blaxel if we can't get the current directory
+			workingDir = "/blaxel"
+		}
+	}
+
 	return &FileSystemHandler{
 		BaseHandler: NewBaseHandler(),
-		fs:          filesystem.NewFilesystem("/"),
+		fs:          filesystem.NewFilesystemWithWorkingDir("/", workingDir),
 	}
+}
+
+// extractPathFromRequest extracts the path from the request and determines if it's relative or absolute
+func (h *FileSystemHandler) extractPathFromRequest(c *gin.Context) string {
+	path := c.Param("path")
+
+	// Check if the request URL explicitly contains %2F (encoded /)
+	rawURL := c.Request.URL.RawPath
+	if rawURL == "" {
+		rawURL = c.Request.URL.Path
+	}
+
+	// If the raw URL contains %2F, it's an explicit absolute path request
+	if strings.Contains(rawURL, "%2F") {
+		// Keep the path as-is for absolute paths
+		return path
+	}
+
+	// If path starts with "/" but doesn't have %2F in the URL, treat as relative
+	// by removing the leading slash (Gin adds it)
+	if path == "/" {
+		// Special case: /filesystem/ means current directory
+		return "."
+	} else if strings.HasPrefix(path, "/") {
+		// Remove leading slash for relative paths like /src -> src
+		return path[1:]
+	}
+
+	return path
 }
 
 // GetWorkingDirectory gets the current working directory
 func (h *FileSystemHandler) GetWorkingDirectory() (string, error) {
-	return h.fs.GetAbsolutePath("/")
+	return h.fs.WorkingDir, nil
 }
 
 // ListDirectory lists the contents of a directory
@@ -110,12 +149,9 @@ func (h *FileSystemHandler) DeleteFile(path string) error {
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /filesystem/{path} [get]
 func (h *FileSystemHandler) HandleGetFile(c *gin.Context) {
-	path, err := h.GetPathParam(c, "path")
-	if err != nil {
-		h.SendError(c, http.StatusBadRequest, err)
-		return
-	}
-	path, err = lib.FormatPath(path)
+	path := h.extractPathFromRequest(c)
+
+	path, err := lib.FormatPath(path)
 	if err != nil {
 		h.SendError(c, http.StatusBadRequest, err)
 		return
@@ -193,12 +229,9 @@ func (h *FileSystemHandler) HandleCreateOrUpdateFile(c *gin.Context) {
 }
 
 func (h *FileSystemHandler) HandleCreateOrUpdateFileJSON(c *gin.Context) {
-	path, err := h.GetPathParam(c, "path")
-	if err != nil {
-		h.SendError(c, http.StatusBadRequest, err)
-		return
-	}
-	path, err = lib.FormatPath(path)
+	path := h.extractPathFromRequest(c)
+
+	path, err := lib.FormatPath(path)
 	if err != nil {
 		h.SendError(c, http.StatusBadRequest, err)
 		return
@@ -245,12 +278,9 @@ func (h *FileSystemHandler) HandleCreateOrUpdateFileJSON(c *gin.Context) {
 
 func (h *FileSystemHandler) HandleCreateOrUpdateBinary(c *gin.Context) {
 	// Get path from form data
-	path, err := h.GetPathParam(c, "path")
-	if err != nil {
-		h.SendError(c, http.StatusBadRequest, err)
-		return
-	}
-	path, err = lib.FormatPath(path)
+	path := h.extractPathFromRequest(c)
+
+	path, err := lib.FormatPath(path)
 	if err != nil {
 		h.SendError(c, http.StatusBadRequest, err)
 		return
@@ -310,28 +340,15 @@ func (h *FileSystemHandler) HandleCreateOrUpdateBinary(c *gin.Context) {
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /filesystem/{path} [delete]
 func (h *FileSystemHandler) HandleDeleteFile(c *gin.Context) {
-	path, err := h.GetPathParam(c, "path")
-	if err != nil {
-		h.SendError(c, http.StatusBadRequest, err)
-		return
-	}
-	path, err = lib.FormatPath(path)
+	path := h.extractPathFromRequest(c)
+
+	path, err := lib.FormatPath(path)
 	if err != nil {
 		h.SendError(c, http.StatusBadRequest, err)
 		return
 	}
 
 	recursive := c.Query("recursive")
-
-	// Default to root if path is empty
-	if path == "" {
-		path = "/"
-	}
-
-	// Ensure path starts with a slash
-	if path != "/" && len(path) > 0 && path[0] != '/' {
-		path = "/" + path
-	}
 
 	// Check if it's a directory
 	isDir, err := h.DirectoryExists(path)
@@ -533,12 +550,9 @@ func (h *FileSystemHandler) HandleDeleteTree(c *gin.Context) {
 // @Failure 500 {object} ErrorResponse "Internal server error"
 // @Router /watch/filesystem/{path} [get]
 func (h *FileSystemHandler) HandleWatchDirectory(c *gin.Context) {
-	path, err := h.GetPathParam(c, "path")
-	if err != nil {
-		h.SendError(c, http.StatusBadRequest, err)
-		return
-	}
-	path, err = lib.FormatPath(path)
+	path := h.extractPathFromRequest(c)
+
+	path, err := lib.FormatPath(path)
 	if err != nil {
 		h.SendError(c, http.StatusBadRequest, err)
 		return
@@ -663,115 +677,6 @@ func (h *FileSystemHandler) HandleWatchDirectory(c *gin.Context) {
 					return
 				}
 				flusher.Flush()
-			}
-		}
-	}()
-
-	<-done
-}
-
-// HandleWatchDirectoryWebSocket streams file modification events for a directory over WebSocket
-// @Summary Stream file modification events in a directory via WebSocket
-// @Description Streams JSON events of modified files in the given directory. Closes when the client disconnects.
-// @Tags filesystem
-// @Produce json
-// @Param path path string true "Directory path to watch"
-// @Success 101 {string} string "WebSocket connection established"
-// @Failure 400 {object} ErrorResponse "Invalid path"
-// @Failure 500 {object} ErrorResponse "Internal server error"
-// @Router /ws/watch/filesystem/{path} [get]
-func (h *FileSystemHandler) HandleWatchDirectoryWebSocket(c *gin.Context) {
-	path, err := h.GetPathParam(c, "path")
-	if err != nil {
-		h.SendError(c, http.StatusBadRequest, err)
-		return
-	}
-	path, err = lib.FormatPath(path)
-	if err != nil {
-		h.SendError(c, http.StatusUnprocessableEntity, err)
-		return
-	}
-
-	// Parse ignore patterns from query param
-	ignoreParam := c.Query("ignore")
-	var ignorePatterns []string
-	if ignoreParam != "" {
-		ignorePatterns = strings.Split(ignoreParam, ",")
-	}
-	shouldIgnore := func(eventPath string) bool {
-		for _, pattern := range ignorePatterns {
-			if pattern != "" && strings.Contains(eventPath, pattern) {
-				return true
-			}
-		}
-		return false
-	}
-
-	isDir, err := h.DirectoryExists(path)
-	if err != nil {
-		h.SendError(c, http.StatusUnprocessableEntity, err)
-		return
-	}
-
-	if !isDir {
-		h.SendError(c, http.StatusBadRequest, fmt.Errorf("path is not a directory"))
-		return
-	}
-
-	upgrader := websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool { return true },
-	}
-	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
-	if err != nil {
-		return
-	}
-	defer conn.Close()
-	done := make(chan struct{})
-	var once sync.Once
-
-	stop, err := h.fs.WatchDirectory(path, func(event fsnotify.Event) {
-		if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename|fsnotify.Chmod) != 0 {
-			if shouldIgnore(event.Name) {
-				return
-			}
-			msg := FileEvent{
-				Op:    event.Op.String(),
-				Name:  strings.Split(event.Name, "/")[len(strings.Split(event.Name, "/"))-1],
-				Path:  strings.Join(strings.Split(event.Name, "/")[:len(strings.Split(event.Name, "/"))-1], "/"),
-				Error: nil,
-			}
-			if err := conn.WriteJSON(msg); err != nil {
-				once.Do(func() { close(done) })
-			}
-		}
-	})
-	if err != nil {
-		conn.WriteJSON(map[string]string{"error": err.Error()})
-		return
-	}
-	defer stop() // Ensures watcher is removed when handler exits
-
-	// Periodic keepalive ping
-	keepaliveTicker := time.NewTicker(30 * time.Second)
-	defer keepaliveTicker.Stop()
-
-	// Reader goroutine to detect client closure
-	go func() {
-		for {
-			_, _, err := conn.ReadMessage()
-			if err != nil {
-				once.Do(func() { close(done) })
-				return
-			}
-		}
-	}()
-
-	// Pinger goroutine to keep the WS alive
-	go func() {
-		for range keepaliveTicker.C {
-			if err := conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(5*time.Second)); err != nil {
-				once.Do(func() { close(done) })
-				return
 			}
 		}
 	}()

--- a/sandbox-api/src/handler/process.go
+++ b/sandbox-api/src/handler/process.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/websocket"
 
 	"github.com/blaxel-ai/sandbox-api/src/handler/constants"
 	"github.com/blaxel-ai/sandbox-api/src/handler/process"
@@ -437,86 +435,4 @@ func (w *ResponseWriter) Close() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.closed = true
-}
-
-// wsWriter is a custom writer to send logs as JSON over WebSocket
-// Used by HandleGetProcessLogsStreamWebSocket
-// Implements io.Writer
-type wsWriter struct {
-	conn *websocket.Conn
-	mu   sync.Mutex
-}
-
-func (w *wsWriter) Write(data []byte) (int, error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	logStr := string(data)
-	logStr = strings.TrimRight(logStr, "\n")
-	msg := map[string]interface{}{"type": "log", "log": logStr}
-	if err := w.conn.WriteJSON(msg); err != nil {
-		return 0, err
-	}
-	return len(data), nil
-}
-
-// HandleGetProcessLogsStreamWebSocket streams process logs in real time over WebSocket
-// @Summary Stream process logs in real time via WebSocket
-// @Description Streams the stdout and stderr output of a process in real time as JSON messages.
-// @Tags process
-// @Produce json
-// @Param identifier path string true "Process identifier (PID or name)"
-// @Success 101 {string} string "WebSocket connection established"
-// @Failure 404 {object} ErrorResponse "Process not found"
-// @Failure 422 {object} ErrorResponse "Unprocessable entity"
-// @Failure 500 {object} ErrorResponse "Internal server error"
-// @Router /ws/process/{identifier}/logs/stream [get]
-func (h *ProcessHandler) HandleGetProcessLogsStreamWebSocket(c *gin.Context) {
-	identifier, err := h.GetPathParam(c, "identifier")
-	if err != nil {
-		h.SendError(c, http.StatusBadRequest, err)
-		return
-	}
-
-	upgrader := websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool { return true },
-	}
-	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
-	if err != nil {
-		return
-	}
-	defer conn.Close()
-	done := make(chan struct{})
-	var once sync.Once
-
-	writer := &wsWriter{conn: conn}
-
-	err = h.StreamProcessOutput(identifier, writer)
-	if err != nil {
-		conn.WriteJSON(map[string]string{"type": "error", "log": err.Error()})
-		return
-	}
-
-	process, exists := h.processManager.GetProcessByIdentifier(identifier)
-	if !exists {
-		return
-	}
-	go func() {
-		for {
-			_, _, err := conn.ReadMessage()
-			if err != nil {
-				once.Do(func() { close(done) })
-				return
-			}
-		}
-	}()
-	for process.Status == constants.ProcessStatusRunning {
-		time.Sleep(200 * time.Millisecond)
-		select {
-		case <-done:
-			h.RemoveLogWriter(identifier, writer)
-			return
-		default:
-		}
-	}
-	h.RemoveLogWriter(identifier, writer)
 }

--- a/sandbox-api/src/lib/path.go
+++ b/sandbox-api/src/lib/path.go
@@ -7,22 +7,23 @@ import (
 )
 
 func FormatPath(path string) (string, error) {
-	// Default to root if path is empty
+	// Default to current directory if path is empty
 	if path == "" {
-		path = "/"
+		path = "."
 	}
-	// Ensure path starts with a slash
-	if path != "/" && len(path) > 0 && path[0] != '/' {
-		path = "/" + path
-	}
-	if strings.HasPrefix(path, "//") {
-		path = path[1:]
-	}
-	if strings.HasPrefix(path, "/~") {
+
+	// Handle home directory expansion
+	if strings.HasPrefix(path, "~") {
 		if os.Getenv("HOME") == "" {
 			return "", fmt.Errorf("home directory not found")
 		}
-		path = os.Getenv("HOME") + path[2:]
+		path = os.Getenv("HOME") + path[1:]
 	}
+
+	// Clean up double slashes
+	for strings.Contains(path, "//") {
+		path = strings.ReplaceAll(path, "//", "/")
+	}
+
 	return path, nil
 }


### PR DESCRIPTION
Adds functions to encode filesystem paths for API requests, handling absolute and relative paths consistently.

Updates integration tests to use the new encoding functions, ensuring correct path handling for file system operations and watch events.

Removes WebSocket endpoints for file system watch and process logs streaming.
