### PR TITLE
docs: add environment details to hub template long descriptions

### DIFF
--- a/hub/astro/template.json
+++ b/hub/astro/template.json
@@ -4,7 +4,7 @@
   "categories": ["web"],
   "description": "A complete development environment for Astro applications with a dev server ready at startup.",
   "icon": "https://astro.build/assets/press/astro-icon-light-gradient.svg",
-  "longDescription": "The Astro micro VM provides a comprehensive development environment for building Astro applications. It includes Node.js runtime, npm package manager, and all necessary tools for building content-driven websites. Features hot reloading, island architecture, and zero JavaScript by default. Perfect for developing fast, content-focused websites with Astro's modern web framework.",
+  "longDescription": "The Astro micro VM provides a comprehensive development environment for building Astro applications. It includes Node.js runtime, npm package manager, and all necessary tools for building content-driven websites. Features hot reloading, island architecture, and zero JavaScript by default. Perfect for developing fast, content-focused websites with Astro's modern web framework. Built on Alpine Linux with Node.js 22, and ships with git, curl, and npm pre-installed.",
   "url": "https://github.com/withastro/astro",
   "memory": 4096,
   "ports": [

--- a/hub/base-image/template.json
+++ b/hub/base-image/template.json
@@ -3,7 +3,7 @@
   "displayName": "Base Image",
   "categories": [],
   "description": "A minimal micro VM environment with basic system utilities and networking capabilities",
-  "longDescription": "The Base Image micro VM provides a lightweight, secure environment with essential system utilities and networking capabilities. It's designed as a foundation for running basic applications and services, featuring a minimal attack surface and optimized resource usage.",
+  "longDescription": "The Base Image micro VM provides a lightweight, secure environment with essential system utilities and networking capabilities. It's designed as a foundation for running basic applications and services, featuring a minimal attack surface and optimized resource usage. Built on Alpine Linux with Node.js 22, and ships with git and npm pre-installed.",
   "url": "https://github.com/firecracker-microvm",
   "icon": "https://avatars.githubusercontent.com/u/44477506?s=200&v=4",
   "memory": 4096,

--- a/hub/chromium/template.json
+++ b/hub/chromium/template.json
@@ -3,7 +3,7 @@
   "displayName": "Chromium",
   "categories": ["browser"],
   "description": "A headless Chromium browser environment with Chrome DevTools Protocol access via nginx proxy.",
-  "longDescription": "The Chromium sandbox provides a headless Chromium browser with Chrome DevTools Protocol (CDP) access through an nginx reverse proxy. It supports remote debugging, browser automation via CDP WebSocket connections, and URL rewriting for seamless access in both internal and external network configurations. Ideal for web scraping, automated testing, and browser-based automation workflows.",
+  "longDescription": "The Chromium sandbox provides a headless Chromium browser with Chrome DevTools Protocol (CDP) access through an nginx reverse proxy. It supports remote debugging, browser automation via CDP WebSocket connections, and URL rewriting for seamless access in both internal and external network configurations. Ideal for web scraping, automated testing, and browser-based automation workflows. Built on Alpine Linux with Chromium 124 and nginx pre-installed.",
   "url": "https://www.chromium.org",
   "icon": "https://avatars.githubusercontent.com/u/30044?s=200&v=4",
   "memory": 4096,

--- a/hub/cua-xfce/template.json
+++ b/hub/cua-xfce/template.json
@@ -3,7 +3,7 @@
   "displayName": "CUA XFCE Desktop",
   "categories": ["computer-use"],
   "description": "A full XFCE desktop environment with VNC/noVNC access and CUA computer-server API for AI-driven computer use.",
-  "longDescription": "The CUA XFCE Desktop sandbox provides a complete XFCE desktop environment accessible via VNC and noVNC (HTML5 browser client). It includes the CUA computer-server API for AI-driven computer use automation, enabling agents to interact with the desktop through screenshots, mouse, and keyboard actions. Managed by supervisord for reliable multi-service orchestration.",
+  "longDescription": "The CUA XFCE Desktop sandbox provides a complete XFCE desktop environment accessible via VNC and noVNC (HTML5 browser client). It includes the CUA computer-server API for AI-driven computer use automation, enabling agents to interact with the desktop through screenshots, mouse, and keyboard actions. Managed by supervisord for reliable multi-service orchestration. Built on Ubuntu with the XFCE desktop environment, TigerVNC, noVNC, and Python pre-installed.",
   "url": "https://github.com/trycua/cua",
   "icon": "https://avatars.githubusercontent.com/u/191107687?s=200&v=4",
   "memory": 4096,

--- a/hub/docker-in-sandbox/template.json
+++ b/hub/docker-in-sandbox/template.json
@@ -4,7 +4,7 @@
   "categories": ["devops"],
   "description": "A development environment for Docker with essential development tools.",
   "icon": "https://avatars.githubusercontent.com/u/5429470?s=200&v=4",
-  "longDescription": "The Docker micro VM provides a comprehensive development environment for building Docker applications. It includes the Docker CLI, development server, and all necessary tools for cross-platform mobile development. Features hot reloading, over-the-air updates, and access to native device features through Expo's managed workflow. Perfect for developing iOS and Android applications with a single codebase.",
+  "longDescription": "The Docker-in-Sandbox micro VM provides a complete Docker development environment running inside a sandbox. It includes the Docker Engine, Docker Compose, and essential development tools for building and running containerized applications. Perfect for developing, testing, and orchestrating Docker containers in an isolated environment. Built on Alpine Linux, and ships with Docker, Docker Compose, git, curl, zsh (with oh-my-zsh), make, and jq pre-installed.",
   "url": "https://github.com/docker",
   "memory": 4096,
   "ports": [

--- a/hub/expo/template.json
+++ b/hub/expo/template.json
@@ -4,7 +4,7 @@
   "categories": ["mobile"],
   "description": "A complete development environment for React Native applications using Expo framework.",
   "icon": "https://avatars.githubusercontent.com/u/12504344?s=200&v=4",
-  "longDescription": "The Expo micro VM provides a comprehensive development environment for building React Native applications using the Expo framework. It includes the Expo CLI, development server, and all necessary tools for cross-platform mobile development. Features hot reloading, over-the-air updates, and access to native device features through Expo's managed workflow. Perfect for developing iOS and Android applications with a single codebase.",
+  "longDescription": "The Expo micro VM provides a comprehensive development environment for building React Native applications using the Expo framework. It includes the Expo CLI, development server, and all necessary tools for cross-platform mobile development. Features hot reloading, over-the-air updates, and access to native device features through Expo's managed workflow. Perfect for developing iOS and Android applications with a single codebase. Built on Alpine Linux with Node.js 22, and ships with git, curl, npm, and the Expo CLI pre-installed.",
   "url": "https://github.com/expo",
   "memory": 4096,
   "ports": [

--- a/hub/jupyter-notebook/template.json
+++ b/hub/jupyter-notebook/template.json
@@ -3,7 +3,7 @@
   "displayName": "Jupyter Notebook",
   "categories": ["data-science"],
   "description": "Interactive Python development environment with Jupyter Kernel Gateway for notebook execution",
-  "longDescription": "Jupyter Notebook provides an interactive computing environment where you can create and share documents containing live code, equations, visualizations, and narrative text. This sandbox includes Jupyter Kernel Gateway, enabling remote kernel execution and RESTful access to Jupyter kernels.",
+  "longDescription": "Jupyter Notebook provides an interactive computing environment where you can create and share documents containing live code, equations, visualizations, and narrative text. This sandbox includes Jupyter Kernel Gateway, enabling remote kernel execution and RESTful access to Jupyter kernels. Built on Debian (slim) with Python 3.12, and ships with git, curl, uv, pip, and Jupyter Kernel Gateway pre-installed.",
   "url": "https://jupyter.org",
   "icon": "https://avatars.githubusercontent.com/u/7388996?s=200&v=4",
   "memory": 4096,

--- a/hub/jupyter-server/template.json
+++ b/hub/jupyter-server/template.json
@@ -3,7 +3,7 @@
   "displayName": "Jupyter Server",
   "categories": ["data-science"],
   "description": "Interactive Python development environment with Jupyter Server for notebook execution",
-  "longDescription": "Jupyter Notebook provides an interactive computing environment where you can create and share documents containing live code, equations, visualizations, and narrative text. This sandbox includes Jupyter Server, enabling remote execution and RESTful access to Jupyter server.",
+  "longDescription": "Jupyter Notebook provides an interactive computing environment where you can create and share documents containing live code, equations, visualizations, and narrative text. This sandbox includes Jupyter Server, enabling remote execution and RESTful access to Jupyter server. Built on Debian (slim) with Python 3.12, and ships with git, curl, uv, pip, Jupyter Server, and a comprehensive data science stack (numpy, pandas, matplotlib, scikit-learn, scipy, seaborn, plotly, OpenCV, and more) pre-installed.",
   "url": "https://jupyter.org",
   "icon": "https://avatars.githubusercontent.com/u/7388996?s=200&v=4",
   "memory": 4096,

--- a/hub/lightpanda/template.json
+++ b/hub/lightpanda/template.json
@@ -3,7 +3,7 @@
   "displayName": "Lightpanda",
   "categories": ["browser"],
   "description": "A lightweight browser environment with Chrome DevTools Protocol support for fast web automation.",
-  "longDescription": "The Lightpanda sandbox provides a lightweight browser optimized for automation tasks with Chrome DevTools Protocol (CDP) compatibility. It offers minimal resource usage while maintaining compatibility with standard browser automation libraries like Puppeteer. Ideal for web scraping, automated testing, PDF generation, and data extraction workflows.",
+  "longDescription": "The Lightpanda sandbox provides a lightweight browser optimized for automation tasks with Chrome DevTools Protocol (CDP) compatibility. It offers minimal resource usage while maintaining compatibility with standard browser automation libraries like Puppeteer. Ideal for web scraping, automated testing, PDF generation, and data extraction workflows. Built on a minimal Linux image with the Lightpanda browser pre-installed.",
   "url": "https://www.lightpanda.io",
   "icon": "https://avatars.githubusercontent.com/u/145980012?s=200&v=4",
   "memory": 1024,

--- a/hub/nextjs/template.json
+++ b/hub/nextjs/template.json
@@ -4,7 +4,7 @@
   "categories": ["web"],
   "description": "A complete development environment for React applications using Next.js framework.",
   "icon": "https://assets.vercel.com/image/upload/v1662130559/nextjs/Icon_dark_background.png",
-  "longDescription": "Next.js is a React framework for building server-side rendered (SSR), static site generation (SSG), and hybrid client-side rendered (CSR) web applications using React. It includes a routing system, a build optimizer, and a development server.",
+  "longDescription": "Next.js is a React framework for building server-side rendered (SSR), static site generation (SSG), and hybrid client-side rendered (CSR) web applications using React. It includes a routing system, a build optimizer, and a development server. Built on Alpine Linux with Node.js 22, and ships with git, curl, and npm pre-installed.",
   "url": "https://github.com/vercel/next.js",
   "memory": 4096,
   "ports": [

--- a/hub/node/template.json
+++ b/hub/node/template.json
@@ -3,7 +3,7 @@
   "displayName": "Node",
   "categories": ["backend"],
   "description": "A development environment for Node.js applications with essential development tools.",
-  "longDescription": "The Node micro VM provides a complete development environment for building Node.js applications. It includes Node.js runtime, npm package manager, and essential development tools. Perfect for developing modern web applications, APIs, and server-side applications with type safety and modern JavaScript features.",
+  "longDescription": "The Node micro VM provides a complete development environment for building Node.js applications. It includes Node.js runtime, npm package manager, and essential development tools. Perfect for developing modern web applications, APIs, and server-side applications with type safety and modern JavaScript features. Built on Alpine Linux with Node.js 23, and ships with git and npm pre-installed.",
   "url": "https://nodejs.org/en",
   "icon": "https://avatars.githubusercontent.com/u/9950313?s=200&v=4",
   "memory": 4096,

--- a/hub/playwright-chromium/template.json
+++ b/hub/playwright-chromium/template.json
@@ -3,7 +3,7 @@
   "displayName": "Playwright Chromium",
   "categories": ["browser", "testing"],
   "description": "A Playwright server environment with Chromium browser for automated browser testing and web scraping.",
-  "longDescription": "The Playwright Chromium sandbox provides a complete Playwright server environment with the Chromium browser pre-installed. It enables automated browser testing, web scraping, and browser automation through Playwright's WebSocket-based protocol. Ideal for running end-to-end tests, generating screenshots, and automating web interactions with Chromium.",
+  "longDescription": "The Playwright Chromium sandbox provides a complete Playwright server environment with the Chromium browser pre-installed. It enables automated browser testing, web scraping, and browser automation through Playwright's WebSocket-based protocol. Ideal for running end-to-end tests, generating screenshots, and automating web interactions with Chromium. Built on Debian Bookworm with Node.js 20, and ships with Playwright 1.58, Chromium, build-essential, net-tools, and npm pre-installed.",
   "url": "https://playwright.dev",
   "icon": "https://playwright.dev/img/playwright-logo.svg",
   "memory": 4096,

--- a/hub/playwright-firefox/template.json
+++ b/hub/playwright-firefox/template.json
@@ -3,7 +3,7 @@
   "displayName": "Playwright Firefox",
   "categories": ["browser", "testing"],
   "description": "A Playwright server environment with Firefox browser for automated browser testing and web scraping.",
-  "longDescription": "The Playwright Firefox sandbox provides a complete Playwright server environment with the Firefox browser pre-installed. It enables automated browser testing, web scraping, and browser automation through Playwright's WebSocket-based protocol. Ideal for running end-to-end tests, generating screenshots, and automating web interactions with Firefox.",
+  "longDescription": "The Playwright Firefox sandbox provides a complete Playwright server environment with the Firefox browser pre-installed. It enables automated browser testing, web scraping, and browser automation through Playwright's WebSocket-based protocol. Ideal for running end-to-end tests, generating screenshots, and automating web interactions with Firefox. Built on Debian Bookworm with Node.js 20, and ships with Playwright 1.58, Firefox, build-essential, net-tools, and npm pre-installed.",
   "url": "https://playwright.dev",
   "icon": "https://playwright.dev/img/playwright-logo.svg",
   "memory": 4096,

--- a/hub/py-app/template.json
+++ b/hub/py-app/template.json
@@ -3,7 +3,7 @@
   "displayName": "Python App",
   "categories": ["backend"],
   "description": "A Python development environment with pip package manager and common development libraries.",
-  "longDescription": "The Python App micro VM provides a complete development environment for Python applications. It includes Python runtime, pip package manager, and common development libraries. Ideal for developing web applications, data science projects, automation scripts, and machine learning applications with Python's rich ecosystem of packages and tools.",
+  "longDescription": "The Python App micro VM provides a complete development environment for Python applications. It includes Python runtime, pip package manager, and common development libraries. Ideal for developing web applications, data science projects, automation scripts, and machine learning applications with Python's rich ecosystem of packages and tools. Built on Debian (slim) with Python 3.12, and ships with git and pip pre-installed.",
   "url": "https://github.com/python",
   "icon": "https://avatars.githubusercontent.com/u/1525981?s=200&v=4",
   "memory": 4096,

--- a/hub/ts-app/template.json
+++ b/hub/ts-app/template.json
@@ -3,7 +3,7 @@
   "displayName": "Typescript App",
   "categories": ["backend"],
   "description": "A development environment for TypeScript applications with Node.js runtime and essential development tools.",
-  "longDescription": "The TypeScript App micro VM provides a complete development environment for building TypeScript applications. It includes Node.js runtime, npm package manager, and essential development tools. Perfect for developing modern web applications, APIs, and server-side applications with type safety and modern JavaScript features.",
+  "longDescription": "The TypeScript App micro VM provides a complete development environment for building TypeScript applications. It includes Node.js runtime, npm package manager, and essential development tools. Perfect for developing modern web applications, APIs, and server-side applications with type safety and modern JavaScript features. Built on Debian (slim) with Node.js 22, and ships with git and npm pre-installed.",
   "url": "https://github.com/microsoft/typescript",
   "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/Typescript.svg/250px-Typescript.svg.png",
   "memory": 2048,

--- a/hub/vibekit-claude/template.json
+++ b/hub/vibekit-claude/template.json
@@ -4,7 +4,7 @@
   "categories": [
   ],
   "description": "A development environment for building AI-powered applications with Claude integration using VibeKit SDK.",
-  "longDescription": "VibeKit provides a complete SDK and UI components for building conversational AI applications powered by Claude. This sandbox includes the VibeKit Claude runtime environment with pre-configured development tools, hot reloading, and all necessary dependencies for creating interactive AI chat interfaces and agent-based applications. Perfect for developing Claude-powered chatbots, AI assistants, and intelligent conversational interfaces with modern React components.",
+  "longDescription": "VibeKit provides a complete SDK and UI components for building conversational AI applications powered by Claude. This sandbox includes the VibeKit Claude runtime environment with pre-configured development tools, hot reloading, and all necessary dependencies for creating interactive AI chat interfaces and agent-based applications. Perfect for developing Claude-powered chatbots, AI assistants, and intelligent conversational interfaces with modern React components. Built on the VibeKit Claude runtime image by SuperAgent AI.",
   "url": "https://docs.vibekit.sh/sdk",
   "icon": "https://avatars.githubusercontent.com/u/152537519?s=200&v=4",
   "memory": 4096,

--- a/hub/vibekit-codex/template.json
+++ b/hub/vibekit-codex/template.json
@@ -4,7 +4,7 @@
   "categories": [
   ],
   "description": "A development environment for building AI-powered applications with OpenAI Codex integration using VibeKit SDK.",
-  "longDescription": "VibeKit provides a complete SDK and UI components for building conversational AI applications powered by OpenAI Codex. This sandbox includes the VibeKit Codex runtime environment with pre-configured development tools, hot reloading, and all necessary dependencies for creating interactive AI chat interfaces and code generation applications. Perfect for developing Codex-powered code assistants, intelligent development tools, and AI-enhanced coding interfaces with modern React components.",
+  "longDescription": "VibeKit provides a complete SDK and UI components for building conversational AI applications powered by OpenAI Codex. This sandbox includes the VibeKit Codex runtime environment with pre-configured development tools, hot reloading, and all necessary dependencies for creating interactive AI chat interfaces and code generation applications. Perfect for developing Codex-powered code assistants, intelligent development tools, and AI-enhanced coding interfaces with modern React components. Built on the VibeKit Codex runtime image by SuperAgent AI.",
   "url": "https://docs.vibekit.sh/sdk",
   "icon": "https://avatars.githubusercontent.com/u/152537519?s=200&v=4",
   "memory": 4096,

--- a/hub/vibekit-gemini/template.json
+++ b/hub/vibekit-gemini/template.json
@@ -4,7 +4,7 @@
   "categories": [
   ],
   "description": "A development environment for building AI-powered applications with Google Gemini integration using VibeKit SDK.",
-  "longDescription": "VibeKit provides a complete SDK and UI components for building conversational AI applications powered by Google Gemini. This sandbox includes the VibeKit Gemini runtime environment with pre-configured development tools, hot reloading, and all necessary dependencies for creating interactive AI chat interfaces and multimodal applications. Perfect for developing Gemini-powered chatbots, AI assistants with vision capabilities, and intelligent conversational interfaces with modern React components.",
+  "longDescription": "VibeKit provides a complete SDK and UI components for building conversational AI applications powered by Google Gemini. This sandbox includes the VibeKit Gemini runtime environment with pre-configured development tools, hot reloading, and all necessary dependencies for creating interactive AI chat interfaces and multimodal applications. Perfect for developing Gemini-powered chatbots, AI assistants with vision capabilities, and intelligent conversational interfaces with modern React components. Built on the VibeKit Gemini runtime image by SuperAgent AI.",
   "url": "https://docs.vibekit.sh/sdk",
   "icon": "https://avatars.githubusercontent.com/u/152537519?s=200&v=4",
   "memory": 4096,

--- a/hub/vibekit-grok/template.json
+++ b/hub/vibekit-grok/template.json
@@ -4,7 +4,7 @@
   "categories": [
   ],
   "description": "A development environment for building AI-powered applications with xAI Grok integration using VibeKit SDK.",
-  "longDescription": "VibeKit provides a complete SDK and UI components for building conversational AI applications powered by xAI's Grok. This sandbox includes the VibeKit Grok runtime environment with pre-configured development tools, hot reloading, and all necessary dependencies for creating interactive AI chat interfaces and real-time knowledge applications. Perfect for developing Grok-powered chatbots, AI assistants with real-time web access, and intelligent conversational interfaces with modern React components.",
+  "longDescription": "VibeKit provides a complete SDK and UI components for building conversational AI applications powered by xAI's Grok. This sandbox includes the VibeKit Grok runtime environment with pre-configured development tools, hot reloading, and all necessary dependencies for creating interactive AI chat interfaces and real-time knowledge applications. Perfect for developing Grok-powered chatbots, AI assistants with real-time web access, and intelligent conversational interfaces with modern React components. Built on the VibeKit Grok runtime image by SuperAgent AI.",
   "url": "https://docs.vibekit.sh/sdk",
   "icon": "https://avatars.githubusercontent.com/u/152537519?s=200&v=4",
   "memory": 4096,

--- a/hub/vibekit-opencode/template.json
+++ b/hub/vibekit-opencode/template.json
@@ -4,7 +4,7 @@
   "categories": [
   ],
   "description": "A development environment for building AI-powered applications with OpenCode integration using VibeKit SDK.",
-  "longDescription": "VibeKit provides a complete SDK and UI components for building conversational AI applications powered by OpenCode models. This sandbox includes the VibeKit OpenCode runtime environment with pre-configured development tools, hot reloading, and all necessary dependencies for creating interactive AI chat interfaces and code generation applications. Perfect for developing open-source AI-powered code assistants, intelligent development tools, and code-focused conversational interfaces with modern React components.",
+  "longDescription": "VibeKit provides a complete SDK and UI components for building conversational AI applications powered by OpenCode models. This sandbox includes the VibeKit OpenCode runtime environment with pre-configured development tools, hot reloading, and all necessary dependencies for creating interactive AI chat interfaces and code generation applications. Perfect for developing open-source AI-powered code assistants, intelligent development tools, and code-focused conversational interfaces with modern React components. Built on the VibeKit OpenCode runtime image by SuperAgent AI.",
   "url": "https://docs.vibekit.sh/sdk",
   "icon": "https://avatars.githubusercontent.com/u/152537519?s=200&v=4",
   "memory": 4096,

--- a/hub/vite/template.json
+++ b/hub/vite/template.json
@@ -5,7 +5,7 @@
     "web"
   ],
   "description": "A simple Vite app",
-  "longDescription": "The Vite app is a simple Vite app with React and TypeScript. It's ideal for building a simple web app.",
+  "longDescription": "The Vite app is a simple Vite app with React and TypeScript. It's ideal for building a simple web app. Built on Alpine Linux with Node.js 22, and ships with git, curl, and npm pre-installed.",
   "url": "https://vitejs.dev",
   "icon": "https://vitejs.dev/logo.svg",
   "memory": 4096,

--- a/hub/xfce-vnc/template.json
+++ b/hub/xfce-vnc/template.json
@@ -3,7 +3,7 @@
   "displayName": "XFCE VNC Desktop",
   "categories": ["computer-use"],
   "description": "A full XFCE desktop environment accessible via VNC and noVNC for remote desktop workflows.",
-  "longDescription": "The XFCE VNC Desktop sandbox provides a complete XFCE desktop environment accessible via VNC and noVNC (HTML5 browser client). It offers a lightweight, full-featured Linux desktop for running GUI applications, browsers, and desktop tools remotely. Managed by supervisord for reliable multi-service orchestration.",
+  "longDescription": "The XFCE VNC Desktop sandbox provides a complete XFCE desktop environment accessible via VNC and noVNC (HTML5 browser client). It offers a lightweight, full-featured Linux desktop for running GUI applications, browsers, and desktop tools remotely. Managed by supervisord for reliable multi-service orchestration. Built on Ubuntu with the XFCE desktop environment, TigerVNC, noVNC, and Python pre-installed.",
   "url": "https://xfce.org",
   "icon": "https://avatars.githubusercontent.com/u/9962578?s=200&v=4",
   "memory": 4096,


### PR DESCRIPTION
Updated `longDescription` fields across all hub templates to include details about the underlying environment, base OS, runtime versions, and pre-installed tools.

- **Astro, Next.js, Vite, Expo**: Added Alpine Linux + Node.js 22 with git, curl, and npm details
- **Node**: Added Alpine Linux + Node.js 23 with git and npm details
- **Base Image**: Added Alpine Linux + Node.js 22 with git and npm details
- **TypeScript App**: Added Debian slim + Node.js 22 with git and npm details
- **Python App**: Added Debian slim + Python 3.12 with git and pip details
- **Jupyter Notebook**: Added Debian slim + Python 3.12 with git, curl, uv, pip, and Jupyter Kernel Gateway details
- **Jupyter Server**: Added Debian slim + Python 3.12 with full data science stack details
- **Playwright Chromium/Firefox**: Added Debian Bookworm + Node.js 20 with Playwright 1.58 and browser details
- **Chromium**: Added Alpine Linux + Chromium 124 and nginx details
- **Lightpanda**: Added minimal Linux image with Lightpanda browser details
- **Docker-in-Sandbox**: Rewrote description to accurately reflect Docker Engine + Compose environment with Alpine Linux and pre-installed tools
- **CUA XFCE Desktop / XFCE VNC**: Added Ubuntu + XFCE, TigerVNC, noVNC, and Python details
- **VibeKit (Claude, Codex, Gemini, Grok, OpenCode)**: Added runtime image attribution to SuperAgent AI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds environment details (base OS, runtime versions, pre-installed tools) to the `longDescription` field of all 22 hub template JSON files. Also fixes the Docker-in-Sandbox description which previously contained copy-pasted React Native/Expo content.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f8ca74a5f97ffa489ad3776e9865f266719c4cdc.</sup>
<!-- /MENDRAL_SUMMARY -->