### PR TITLE
fix: account for naturally completed processes during upgrade recovery

### DIFF
--- a/sandbox-api/src/handler/process/state.go
+++ b/sandbox-api/src/handler/process/state.go
@@ -1096,7 +1096,12 @@ func waitForHealthy(baseURL string, timeout time.Duration) error {
 	return fmt.Errorf("health check timed out after %v", timeout)
 }
 
-// verifyProcessRecovery checks that the new instance recovered processes correctly
+// verifyProcessRecovery checks that the new instance recovered processes correctly.
+// The running count check tolerates processes that transitioned from running to
+// completed between the moment we captured the current instance's counts and the
+// moment the validation binary's monitorAdoptedProcess detected the exit.
+// A process completing naturally is fine; what we want to catch is processes that
+// were silently lost (not recovered at all).
 func verifyProcessRecovery(baseURL string, expectedTotal, expectedRunning int) error {
 	logger := logrus.WithField("component", "upgrade")
 
@@ -1118,17 +1123,24 @@ func verifyProcessRecovery(baseURL string, expectedTotal, expectedRunning int) e
 
 	recoveredTotal := len(processes)
 	recoveredRunning := 0
+	recoveredCompleted := 0
 	for _, p := range processes {
-		if status, ok := p["status"].(string); ok && status == string(StatusRunning) {
-			recoveredRunning++
+		if status, ok := p["status"].(string); ok {
+			switch status {
+			case string(StatusRunning):
+				recoveredRunning++
+			case string(StatusCompleted), string(StatusFailed):
+				recoveredCompleted++
+			}
 		}
 	}
 
 	logger.WithFields(logrus.Fields{
-		"expectedTotal":    expectedTotal,
-		"recoveredTotal":   recoveredTotal,
-		"expectedRunning":  expectedRunning,
-		"recoveredRunning": recoveredRunning,
+		"expectedTotal":      expectedTotal,
+		"recoveredTotal":     recoveredTotal,
+		"expectedRunning":    expectedRunning,
+		"recoveredRunning":   recoveredRunning,
+		"recoveredCompleted": recoveredCompleted,
 	}).Info("Process recovery comparison")
 
 	// Process recovery is mandatory - if we can't recover processes, fail the upgrade
@@ -1136,9 +1148,24 @@ func verifyProcessRecovery(baseURL string, expectedTotal, expectedRunning int) e
 		return fmt.Errorf("process count mismatch: expected %d, got %d - upgrade aborted to preserve running processes", expectedTotal, recoveredTotal)
 	}
 
-	// Verify running processes were recovered
-	if recoveredRunning != expectedRunning {
-		return fmt.Errorf("running process count mismatch: expected %d running, got %d - upgrade aborted", expectedRunning, recoveredRunning)
+	// Verify running processes were recovered. A process may have completed
+	// between the moment we counted (current instance) and when the validation
+	// binary's monitorAdoptedProcess detected the exit. That is acceptable:
+	// recovered running + those that naturally completed must account for all
+	// the processes we expected to be running.
+	if recoveredRunning < expectedRunning {
+		// Some "expected running" processes may now show as completed/failed
+		// in the validation binary. That is OK as long as the total still adds up.
+		missingRunning := expectedRunning - recoveredRunning
+		if missingRunning > recoveredCompleted {
+			return fmt.Errorf("running process count mismatch: expected %d running, got %d (with %d completed) - upgrade aborted",
+				expectedRunning, recoveredRunning, recoveredCompleted)
+		}
+		logger.WithFields(logrus.Fields{
+			"expectedRunning":          expectedRunning,
+			"recoveredRunning":         recoveredRunning,
+			"naturallyCompletedDuring": missingRunning,
+		}).Info("Some processes completed during validation window, counts are consistent")
 	}
 
 	logger.Info("All processes recovered successfully")

--- a/sandbox-api/src/handler/process/state.go
+++ b/sandbox-api/src/handler/process/state.go
@@ -1154,12 +1154,18 @@ func verifyProcessRecovery(baseURL string, expectedTotal, expectedRunning int) e
 	// recovered running + those that naturally completed must account for all
 	// the processes we expected to be running.
 	if recoveredRunning < expectedRunning {
-		// Some "expected running" processes may now show as completed/failed
-		// in the validation binary. That is OK as long as the total still adds up.
 		missingRunning := expectedRunning - recoveredRunning
-		if missingRunning > recoveredCompleted {
-			return fmt.Errorf("running process count mismatch: expected %d running, got %d (with %d completed) - upgrade aborted",
-				expectedRunning, recoveredRunning, recoveredCompleted)
+		// recoveredCompleted includes pre-existing completed processes.
+		// Only the excess beyond expectedCompleted can account for processes
+		// that transitioned during the validation window.
+		expectedCompleted := expectedTotal - expectedRunning
+		newlyCompleted := recoveredCompleted - expectedCompleted
+		if newlyCompleted < 0 {
+			newlyCompleted = 0
+		}
+		if missingRunning > newlyCompleted {
+			return fmt.Errorf("running process count mismatch: expected %d running, got %d (with %d newly completed) - upgrade aborted",
+				expectedRunning, recoveredRunning, newlyCompleted)
 		}
 		logger.WithFields(logrus.Fields{
 			"expectedRunning":          expectedRunning,


### PR DESCRIPTION
Update the process recovery verification to tolerate processes that transition from running to completed or failed states during the validation window. This prevents false-positive count mismatches and upgrade abortions when processes finish naturally between the moment state is captured and the moment the new binary verifies recovery.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR fixes `verifyProcessRecovery` to tolerate processes that naturally transition from running to completed/failed during the upgrade validation window. It adds a `recoveredCompleted` counter and replaces the strict equality check on running counts with a tolerance check that accounts for processes completing between state capture and validation.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c5c4e2c7431a4ae6582624446f46814d3c49c1fe.</sup>
<!-- /MENDRAL_SUMMARY -->