### PR TITLE
fix: rename drive API types to consistent naming

### DIFF
--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -146,6 +146,134 @@ const docTemplate = `{
                 }
             }
         },
+        "/drives/attach": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Mounts an agent drive using the blfs binary to a local path, optionally mounting a subpath within the drive",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "drive"
+                ],
+                "summary": "Attach a drive to a local path",
+                "parameters": [
+                    {
+                        "description": "Drive attachment parameters",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/DriveMountRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/DriveMountResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/drives/mount/{mountPath}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Unmounts a previously mounted drive from the specified local path",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "drive"
+                ],
+                "summary": "Detach a drive from a local path",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Mount path to detach (must start with /, e.g. /mnt/test)",
+                        "name": "mountPath",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/DriveUnmountResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/drives/mounts": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a list of all currently mounted drives managed by blfs",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "drive"
+                ],
+                "summary": "List currently mounted drives",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/DriveListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/filesystem-content-search/{path}": {
             "get": {
                 "description": "Searches for text content inside files using ripgrep. Returns matching lines with context.",
@@ -1797,6 +1925,84 @@ const docTemplate = `{
                 }
             }
         },
+        "DriveListResponse": {
+            "type": "object",
+            "properties": {
+                "mounts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DriveMountInfo"
+                    }
+                }
+            }
+        },
+        "DriveMountInfo": {
+            "type": "object",
+            "properties": {
+                "driveName": {
+                    "type": "string"
+                },
+                "drivePath": {
+                    "type": "string"
+                },
+                "mountPath": {
+                    "type": "string"
+                }
+            }
+        },
+        "DriveMountRequest": {
+            "type": "object",
+            "required": [
+                "driveName",
+                "mountPath"
+            ],
+            "properties": {
+                "driveName": {
+                    "type": "string"
+                },
+                "drivePath": {
+                    "description": "Optional, defaults to \"/\"",
+                    "type": "string"
+                },
+                "mountPath": {
+                    "type": "string"
+                }
+            }
+        },
+        "DriveMountResponse": {
+            "type": "object",
+            "properties": {
+                "driveName": {
+                    "type": "string"
+                },
+                "drivePath": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "mountPath": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "DriveUnmountResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "mountPath": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
         "ErrorResponse": {
             "type": "object",
             "required": [
@@ -2186,7 +2392,6 @@ const docTemplate = `{
                     }
                 },
                 "keepAlive": {
-                    "description": "Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.",
                     "type": "boolean",
                     "example": false
                 },
@@ -2203,7 +2408,6 @@ const docTemplate = `{
                     "example": true
                 },
                 "timeout": {
-                    "description": "Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).",
                     "type": "integer",
                     "example": 30
                 },
@@ -2256,7 +2460,6 @@ const docTemplate = `{
                     "example": 0
                 },
                 "keepAlive": {
-                    "description": "Whether scale-to-zero is disabled for this process",
                     "type": "boolean",
                     "example": false
                 },
@@ -2533,6 +2736,12 @@ const docTemplate = `{
                 "UpgradeStateIdle": "No upgrade in progress",
                 "UpgradeStateRunning": "Upgrade is currently running"
             },
+            "x-enum-descriptions": [
+                "No upgrade in progress",
+                "Upgrade is currently running",
+                "Upgrade completed successfully",
+                "Upgrade failed"
+            ],
             "x-enum-varnames": [
                 "UpgradeStateIdle",
                 "UpgradeStateRunning",

--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -2392,6 +2392,7 @@ const docTemplate = `{
                     }
                 },
                 "keepAlive": {
+                    "description": "Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.",
                     "type": "boolean",
                     "example": false
                 },
@@ -2408,6 +2409,7 @@ const docTemplate = `{
                     "example": true
                 },
                 "timeout": {
+                    "description": "Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).",
                     "type": "integer",
                     "example": 30
                 },
@@ -2460,6 +2462,7 @@ const docTemplate = `{
                     "example": 0
                 },
                 "keepAlive": {
+                    "description": "Whether scale-to-zero is disabled for this process",
                     "type": "boolean",
                     "example": false
                 },

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -1913,6 +1913,7 @@ components:
             "{\"PORT\"": ' "3000"}'
           type: object
         keepAlive:
+          description: Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.
           example: false
           type: boolean
         maxRestarts:
@@ -1925,6 +1926,7 @@ components:
           example: true
           type: boolean
         timeout:
+          description: Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).
           example: 30
           type: integer
         waitForCompletion:
@@ -1955,6 +1957,7 @@ components:
           example: 0
           type: integer
         keepAlive:
+          description: Whether scale-to-zero is disabled for this process
           example: false
           type: boolean
         logs:

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -161,6 +161,95 @@ paths:
       summary: Code reranking/semantic search
       tags:
         - codegen
+  /drives/attach:
+    post:
+      description: Mounts an agent drive using the blfs binary to a local path, optionally mounting a subpath within the drive
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DriveMountRequest"
+        description: Drive attachment parameters
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DriveMountResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      security:
+        - BearerAuth: []
+      summary: Attach a drive to a local path
+      tags:
+        - drive
+  "/drives/mount/{mountPath}":
+    delete:
+      description: Unmounts a previously mounted drive from the specified local path
+      parameters:
+        - description: Mount path to detach (must start with /, e.g. /mnt/test)
+          in: path
+          name: mountPath
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DriveUnmountResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      security:
+        - BearerAuth: []
+      summary: Detach a drive from a local path
+      tags:
+        - drive
+  /drives/mounts:
+    get:
+      description: Returns a list of all currently mounted drives managed by blfs
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DriveListResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      security:
+        - BearerAuth: []
+      summary: List currently mounted drives
+      tags:
+        - drive
   "/filesystem-content-search/{path}":
     get:
       description: Searches for text content inside files using ripgrep. Returns matching lines with context.
@@ -1498,6 +1587,57 @@ components:
         - path
         - subdirectories
       type: object
+    DriveListResponse:
+      properties:
+        mounts:
+          items:
+            $ref: "#/components/schemas/DriveMountInfo"
+          type: array
+      type: object
+    DriveMountInfo:
+      properties:
+        driveName:
+          type: string
+        drivePath:
+          type: string
+        mountPath:
+          type: string
+      type: object
+    DriveMountRequest:
+      properties:
+        driveName:
+          type: string
+        drivePath:
+          description: Optional, defaults to "/"
+          type: string
+        mountPath:
+          type: string
+      required:
+        - driveName
+        - mountPath
+      type: object
+    DriveMountResponse:
+      properties:
+        driveName:
+          type: string
+        drivePath:
+          type: string
+        message:
+          type: string
+        mountPath:
+          type: string
+        success:
+          type: boolean
+      type: object
+    DriveUnmountResponse:
+      properties:
+        message:
+          type: string
+        mountPath:
+          type: string
+        success:
+          type: boolean
+      type: object
     ErrorResponse:
       properties:
         error:
@@ -1773,7 +1913,6 @@ components:
             "{\"PORT\"": ' "3000"}'
           type: object
         keepAlive:
-          description: Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.
           example: false
           type: boolean
         maxRestarts:
@@ -1786,7 +1925,6 @@ components:
           example: true
           type: boolean
         timeout:
-          description: Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).
           example: 30
           type: integer
         waitForCompletion:
@@ -1817,7 +1955,6 @@ components:
           example: 0
           type: integer
         keepAlive:
-          description: Whether scale-to-zero is disabled for this process
           example: false
           type: boolean
         logs:
@@ -2028,6 +2165,11 @@ components:
         UpgradeStateFailed: Upgrade failed
         UpgradeStateIdle: No upgrade in progress
         UpgradeStateRunning: Upgrade is currently running
+      x-enum-descriptions:
+        - No upgrade in progress
+        - Upgrade is currently running
+        - Upgrade completed successfully
+        - Upgrade failed
       x-enum-varnames:
         - UpgradeStateIdle
         - UpgradeStateRunning

--- a/sandbox-api/src/handler/drive.go
+++ b/sandbox-api/src/handler/drive.go
@@ -20,40 +20,40 @@ func NewDriveHandler() *DriveHandler {
 	}
 }
 
-// AttachDriveRequest represents the request body for attaching a drive
-type AttachDriveRequest struct {
+// DriveMountRequest represents the request body for mounting a drive
+type DriveMountRequest struct {
 	DriveName string `json:"driveName" binding:"required"`
 	MountPath string `json:"mountPath" binding:"required"`
 	DrivePath string `json:"drivePath"` // Optional, defaults to "/"
-}
+} // @name DriveMountRequest
 
-// AttachDriveResponse represents the response for a successful drive attachment
-type AttachDriveResponse struct {
+// DriveMountResponse represents the response for a successful drive mount
+type DriveMountResponse struct {
 	Success   bool   `json:"success"`
 	Message   string `json:"message"`
 	DriveName string `json:"driveName"`
 	MountPath string `json:"mountPath"`
 	DrivePath string `json:"drivePath"`
-}
+} // @name DriveMountResponse
 
-// DetachDriveResponse represents the response for a successful drive detachment
-type DetachDriveResponse struct {
+// DriveUnmountResponse represents the response for a successful drive unmount
+type DriveUnmountResponse struct {
 	Success   bool   `json:"success"`
 	Message   string `json:"message"`
 	MountPath string `json:"mountPath"`
-}
+} // @name DriveUnmountResponse
 
-// MountInfo represents information about a mounted drive
-type MountInfo struct {
+// DriveMountInfo represents information about a mounted drive
+type DriveMountInfo struct {
 	DriveName string `json:"driveName"`
 	MountPath string `json:"mountPath"`
 	DrivePath string `json:"drivePath"`
-}
+} // @name DriveMountInfo
 
-// ListMountsResponse represents the response for listing mounted drives
-type ListMountsResponse struct {
-	Mounts []MountInfo `json:"mounts"`
-}
+// DriveListResponse represents the response for listing mounted drives
+type DriveListResponse struct {
+	Mounts []DriveMountInfo `json:"mounts"`
+} // @name DriveListResponse
 
 // AttachDrive godoc
 // @Summary      Attach a drive to a local path
@@ -61,14 +61,14 @@ type ListMountsResponse struct {
 // @Tags         drive
 // @Accept       json
 // @Produce      json
-// @Param        request body AttachDriveRequest true "Drive attachment parameters"
-// @Success      200 {object} AttachDriveResponse
+// @Param        request body DriveMountRequest true "Drive attachment parameters"
+// @Success      200 {object} DriveMountResponse
 // @Failure      400 {object} ErrorResponse
 // @Failure      500 {object} ErrorResponse
 // @Security     BearerAuth
 // @Router       /drives/attach [post]
 func (h *DriveHandler) AttachDrive(c *gin.Context) {
-	var req AttachDriveRequest
+	var req DriveMountRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logrus.WithError(err).Error("Failed to bind JSON for drive attachment")
 		c.JSON(http.StatusBadRequest, ErrorResponse{
@@ -132,7 +132,7 @@ func (h *DriveHandler) AttachDrive(c *gin.Context) {
 		"drive_path": req.DrivePath,
 	}).Info("Drive attached successfully")
 
-	c.JSON(http.StatusOK, AttachDriveResponse{
+	c.JSON(http.StatusOK, DriveMountResponse{
 		Success:   true,
 		Message:   "Drive mounted successfully",
 		DriveName: req.DriveName,
@@ -147,7 +147,7 @@ func (h *DriveHandler) AttachDrive(c *gin.Context) {
 // @Tags         drive
 // @Produce      json
 // @Param        mountPath path string true "Mount path to detach (must start with /, e.g. /mnt/test)"
-// @Success      200 {object} DetachDriveResponse
+// @Success      200 {object} DriveUnmountResponse
 // @Failure      400 {object} ErrorResponse
 // @Failure      500 {object} ErrorResponse
 // @Security     BearerAuth
@@ -178,7 +178,7 @@ func (h *DriveHandler) DetachDrive(c *gin.Context) {
 
 	logrus.WithField("mount_path", mountPath).Info("Drive detached successfully")
 
-	c.JSON(http.StatusOK, DetachDriveResponse{
+	c.JSON(http.StatusOK, DriveUnmountResponse{
 		Success:   true,
 		Message:   "Drive unmounted successfully",
 		MountPath: mountPath,
@@ -190,7 +190,7 @@ func (h *DriveHandler) DetachDrive(c *gin.Context) {
 // @Description  Returns a list of all currently mounted drives managed by blfs
 // @Tags         drive
 // @Produce      json
-// @Success      200 {object} ListMountsResponse
+// @Success      200 {object} DriveListResponse
 // @Failure      500 {object} ErrorResponse
 // @Security     BearerAuth
 // @Router       /drives/mounts [get]
@@ -207,11 +207,11 @@ func (h *DriveHandler) ListMounts(c *gin.Context) {
 	}
 
 	// Convert internal mount info to API response format
-	response := ListMountsResponse{
-		Mounts: make([]MountInfo, len(mounts)),
+	response := DriveListResponse{
+		Mounts: make([]DriveMountInfo, len(mounts)),
 	}
 	for i, m := range mounts {
-		response.Mounts[i] = MountInfo{
+		response.Mounts[i] = DriveMountInfo{
 			DriveName: m.DriveName,
 			MountPath: m.MountPath,
 			DrivePath: m.DrivePath,

--- a/sandbox-api/src/handler/process.go
+++ b/sandbox-api/src/handler/process.go
@@ -52,11 +52,11 @@ type ProcessRequest struct {
 	WorkingDir        string            `json:"workingDir" example:"/home/user"`
 	Env               map[string]string `json:"env" example:"{\"PORT\": \"3000\"}"`
 	WaitForCompletion bool              `json:"waitForCompletion" example:"false"`
-	Timeout           *int              `json:"timeout,omitempty" example:"30"`
+	Timeout           *int              `json:"timeout,omitempty" example:"30"` // Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).
 	WaitForPorts      []int             `json:"waitForPorts" example:"3000,8080"`
 	RestartOnFailure  bool              `json:"restartOnFailure" example:"true"`
 	MaxRestarts       int               `json:"maxRestarts" example:"3"`
-	KeepAlive         bool              `json:"keepAlive" example:"false"`
+	KeepAlive         bool              `json:"keepAlive" example:"false"` // Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.
 } // @name ProcessRequest
 
 // ProcessResponse is the response body for a process
@@ -75,7 +75,7 @@ type ProcessResponse struct {
 	RestartOnFailure bool    `json:"restartOnFailure" example:"true"`
 	MaxRestarts      int     `json:"maxRestarts" example:"3"`
 	RestartCount     int     `json:"restartCount" example:"2"`
-	KeepAlive        bool    `json:"keepAlive" example:"false"`
+	KeepAlive        bool    `json:"keepAlive" example:"false"` // Whether scale-to-zero is disabled for this process
 } // @name ProcessResponse
 
 type ProcessResponseWithLogs struct {


### PR DESCRIPTION
## Summary
- Renamed drive API types to follow a consistent `Drive*` naming convention: `DriveMountRequest`, `DriveMountResponse`, `DriveUnmountResponse`, `DriveMountInfo`, `DriveListResponse`
- Added `// @name` swag annotations to prevent `handler.` prefix in generated OpenAPI spec
- Regenerated OpenAPI docs via `make reference`

## Test plan
- [x] `go build ./...` passes
- [x] `make reference` generates clean type names without `handler.` prefix
- [ ] Verify SDK codegen produces correct type names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Renames drive API handler types from `Attach/Detach/List`-prefixed names to a consistent `Drive*` convention (`DriveMountRequest`, `DriveMountResponse`, `DriveUnmountResponse`, `DriveMountInfo`, `DriveListResponse`), adds `// @name` swag annotations to control generated OpenAPI type names, and regenerates the OpenAPI docs accordingly. Also restores inline comments on `keepAlive`/`timeout` fields in `ProcessRequest`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d37a8b3f45047961b68ece2accfd8e88566692cc.</sup>
<!-- /MENDRAL_SUMMARY -->