### PR TITLE
fix: align drive swagger routes with actual router endpoints

### DIFF
--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -2392,6 +2392,7 @@ const docTemplate = `{
                     }
                 },
                 "keepAlive": {
+                    "description": "Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.",
                     "type": "boolean",
                     "example": false
                 },
@@ -2408,6 +2409,7 @@ const docTemplate = `{
                     "example": true
                 },
                 "timeout": {
+                    "description": "Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).",
                     "type": "integer",
                     "example": 30
                 },
@@ -2460,6 +2462,7 @@ const docTemplate = `{
                     "example": 0
                 },
                 "keepAlive": {
+                    "description": "Whether scale-to-zero is disabled for this process",
                     "type": "boolean",
                     "example": false
                 },

--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -2392,7 +2392,6 @@ const docTemplate = `{
                     }
                 },
                 "keepAlive": {
-                    "description": "Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.",
                     "type": "boolean",
                     "example": false
                 },
@@ -2409,7 +2408,6 @@ const docTemplate = `{
                     "example": true
                 },
                 "timeout": {
-                    "description": "Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).",
                     "type": "integer",
                     "example": 30
                 },
@@ -2462,7 +2460,6 @@ const docTemplate = `{
                     "example": 0
                 },
                 "keepAlive": {
-                    "description": "Whether scale-to-zero is disabled for this process",
                     "type": "boolean",
                     "example": false
                 },

--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -146,7 +146,36 @@ const docTemplate = `{
                 }
             }
         },
-        "/drives/attach": {
+        "/drives/mount": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a list of all currently mounted drives managed by blfs",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "drive"
+                ],
+                "summary": "List currently mounted drives",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/DriveListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -232,37 +261,6 @@ const docTemplate = `{
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/drives/mounts": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns a list of all currently mounted drives managed by blfs",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "drive"
-                ],
-                "summary": "List currently mounted drives",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/DriveListResponse"
                         }
                     },
                     "500": {

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -1913,7 +1913,6 @@ components:
             "{\"PORT\"": ' "3000"}'
           type: object
         keepAlive:
-          description: Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.
           example: false
           type: boolean
         maxRestarts:
@@ -1926,7 +1925,6 @@ components:
           example: true
           type: boolean
         timeout:
-          description: Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).
           example: 30
           type: integer
         waitForCompletion:
@@ -1957,7 +1955,6 @@ components:
           example: 0
           type: integer
         keepAlive:
-          description: Whether scale-to-zero is disabled for this process
           example: false
           type: boolean
         logs:

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -1913,6 +1913,7 @@ components:
             "{\"PORT\"": ' "3000"}'
           type: object
         keepAlive:
+          description: Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.
           example: false
           type: boolean
         maxRestarts:
@@ -1925,6 +1926,7 @@ components:
           example: true
           type: boolean
         timeout:
+          description: Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).
           example: 30
           type: integer
         waitForCompletion:
@@ -1955,6 +1957,7 @@ components:
           example: 0
           type: integer
         keepAlive:
+          description: Whether scale-to-zero is disabled for this process
           example: false
           type: boolean
         logs:

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -161,7 +161,27 @@ paths:
       summary: Code reranking/semantic search
       tags:
         - codegen
-  /drives/attach:
+  /drives/mount:
+    get:
+      description: Returns a list of all currently mounted drives managed by blfs
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DriveListResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      security:
+        - BearerAuth: []
+      summary: List currently mounted drives
+      tags:
+        - drive
     post:
       description: Mounts an agent drive using the blfs binary to a local path, optionally mounting a subpath within the drive
       requestBody:
@@ -227,27 +247,6 @@ paths:
       security:
         - BearerAuth: []
       summary: Detach a drive from a local path
-      tags:
-        - drive
-  /drives/mounts:
-    get:
-      description: Returns a list of all currently mounted drives managed by blfs
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DriveListResponse"
-        "500":
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-      security:
-        - BearerAuth: []
-      summary: List currently mounted drives
       tags:
         - drive
   "/filesystem-content-search/{path}":

--- a/sandbox-api/src/handler/drive.go
+++ b/sandbox-api/src/handler/drive.go
@@ -66,7 +66,7 @@ type DriveListResponse struct {
 // @Failure      400 {object} ErrorResponse
 // @Failure      500 {object} ErrorResponse
 // @Security     BearerAuth
-// @Router       /drives/attach [post]
+// @Router       /drives/mount [post]
 func (h *DriveHandler) AttachDrive(c *gin.Context) {
 	var req DriveMountRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -193,7 +193,7 @@ func (h *DriveHandler) DetachDrive(c *gin.Context) {
 // @Success      200 {object} DriveListResponse
 // @Failure      500 {object} ErrorResponse
 // @Security     BearerAuth
-// @Router       /drives/mounts [get]
+// @Router       /drives/mount [get]
 func (h *DriveHandler) ListMounts(c *gin.Context) {
 	logrus.Info("Listing mounted drives")
 


### PR DESCRIPTION
## Summary
- Fixed swagger `@Router` annotations in `drive.go` to match the actual gin router endpoints
  - `POST /drives/attach` -> `POST /drives/mount`
  - `GET /drives/mounts` -> `GET /drives/mount`
- Regenerated OpenAPI docs via `make reference`

## Test plan
- [x] `go build ./...` passes
- [x] `make reference` generates correct routes
- [ ] Verify SDK codegen matches actual endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Aligns Swagger/OpenAPI route annotations with the actual gin router endpoints: renames `/drives/attach` → `/drives/mount` (POST) and `/drives/mounts` → `/drives/mount` (GET), consolidating both operations under the same `/drives/mount` path. Regenerates `docs.go` and `openapi.yml` accordingly.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit de5319a380b7ea94665cf78364ca400032ca2c72.</sup>
<!-- /MENDRAL_SUMMARY -->