### PR TITLE
Update base image with python3

### DIFF
--- a/hub/base-image/Dockerfile
+++ b/hub/base-image/Dockerfile
@@ -5,6 +5,8 @@ FROM node:22-alpine
 
 RUN apk update && apk add --no-cache \
   git \
+  python3 \
+  py3-pip \
   && rm -rf /var/cache/apk/*
 
 WORKDIR /blaxel


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `python3` and `py3-pip` to the Alpine-based Node.js Docker image to support Python tooling in the sandbox base image.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ebb0bf88385f052dd6a6fed284230514431afd0c.</sup>
<!-- /MENDRAL_SUMMARY -->