### PR TITLE
Add bash by default for agent it is better than SH

### DIFF
--- a/hub/astro/Dockerfile
+++ b/hub/astro/Dockerfile
@@ -4,8 +4,9 @@ FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 FROM node:22-alpine
 
 RUN apk update && apk add --no-cache \
-  git \
+  bash \
   curl \
+  git \
   netcat-openbsd \
   && rm -rf /var/cache/apk/*
 

--- a/hub/base-image/Dockerfile
+++ b/hub/base-image/Dockerfile
@@ -4,6 +4,7 @@ FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 FROM node:22-alpine
 
 RUN apk update && apk add --no-cache \
+  bash \
   git \
   python3 \
   py3-pip \

--- a/hub/chromium/Dockerfile
+++ b/hub/chromium/Dockerfile
@@ -7,7 +7,7 @@ COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
 
 # Install nginx with perl module to act as a proxy for host header mapping
 USER root
-RUN apk add --no-cache nginx nginx-mod-http-perl
+RUN apk add --no-cache bash nginx nginx-mod-http-perl
 
 # Replace the default nginx configuration with our proxy config
 COPY hub/chromium/nginx.conf /etc/nginx/nginx.conf

--- a/hub/docker-in-sandbox/Dockerfile
+++ b/hub/docker-in-sandbox/Dockerfile
@@ -1,16 +1,17 @@
 FROM alpine
 
 RUN apk update && apk add --no-cache \
-  git \
+  bash \
   curl \
   docker \
   docker-cli-compose \
-  netcat-openbsd \
+  git \
   iptables \
   iptables-legacy \
-  zsh \
-  make \
   jq \
+  make \
+  netcat-openbsd \
+  zsh \
   && rm -rf /var/cache/apk/*
 
 # The sandbox kernel doesn't support nftables, so switch to iptables-legacy

--- a/hub/expo/Dockerfile
+++ b/hub/expo/Dockerfile
@@ -4,8 +4,9 @@ FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 FROM node:22-alpine
 
 RUN apk update && apk add --no-cache \
-  git \
+  bash \
   curl \
+  git \
   netcat-openbsd \
   && rm -rf /var/cache/apk/*
 

--- a/hub/nextjs/Dockerfile
+++ b/hub/nextjs/Dockerfile
@@ -4,8 +4,9 @@ FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 FROM node:22-alpine
 
 RUN apk update && apk add --no-cache \
-  git \
+  bash \
   curl \
+  git \
   netcat-openbsd \
   && rm -rf /var/cache/apk/*
 

--- a/hub/node/Dockerfile
+++ b/hub/node/Dockerfile
@@ -4,6 +4,7 @@ FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 FROM node:23-alpine
 
 RUN apk update && apk add --no-cache \
+  bash \
   git \
   && rm -rf /var/cache/apk/*
 

--- a/hub/vite/Dockerfile
+++ b/hub/vite/Dockerfile
@@ -4,8 +4,9 @@ FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 FROM node:22-alpine
 
 RUN apk update && apk add --no-cache \
-  git \
+  bash \
   curl \
+  git \
   netcat-openbsd \
   && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `bash` to all hub Dockerfiles (astro, base-image, chromium, docker-in-sandbox, expo, nextjs, node, vite) that previously only had `sh` (Alpine's default). The `docker-in-sandbox` image also reorders packages alphabetically and removes the redundant `zsh` (kept) while reorganizing the list.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7e00255a8cef5a7c2d5dd69f7cc2389a89b172c9.</sup>
<!-- /MENDRAL_SUMMARY -->