### PR TITLE
feat: add app-runner sandbox image

### DIFF
--- a/.agents/skills/add-hub-template/SKILL.md
+++ b/.agents/skills/add-hub-template/SKILL.md
@@ -1,77 +1,85 @@
 ---
 name: add-hub-template
-description: Create a new sandbox hub template (a pre-configured micro VM environment). Use when adding support for a new language, framework, or toolchain as a reusable sandbox image.
+description: Add or update a Blaxel Sandbox Hub image/template under hub/. Use when adding a new hub image, sandbox image, runtime image, template.json, Dockerfile, hidden/internal image, or workflow-dispatch build option in the blaxel-ai/sandbox repository.
 ---
 
-# Add a New Hub Template
+# Add a Sandbox Hub Image
 
-Hub templates are pre-built sandbox images stored in `hub/<template-name>/`. Each template is a Docker image with a `sandbox-api` binary pre-installed and a configured entrypoint.
+Use this skill for new images under `hub/<name>/`, including visible templates and hidden/internal runtime images.
 
-## Step 1: Create the Template Directory
+## Scope First
 
-```bash
-mkdir hub/<template-name>
-```
+1. Check repository instructions at the relevant scope before editing.
+2. Inspect nearby templates:
+   - generic base: `hub/base-image`, `hub/node`, `hub/ts-app`, `hub/py-app`
+   - entrypoint examples: `hub/expo`, `hub/vite`, `hub/nextjs`
+   - hidden/internal examples: `hub/benchmark`, `hub/vibekit-*`
+3. Check the current git status and preserve unrelated user changes.
+4. Decide whether the image is user-facing or internal:
+   - User-facing: add useful metadata and README mention.
+   - Internal/platform-managed: set `"hidden": true` and avoid README marketing.
 
-Convention: use lowercase kebab-case (e.g., `ruby-app`, `go-app`, `playwright-firefox`).
+## Required Files
 
----
+Create or update:
 
-## Step 2: Write the Dockerfile
+- `hub/<name>/Dockerfile`
+- `hub/<name>/template.json`
+- `.github/workflows/build.yaml`
 
-Create `hub/<template-name>/Dockerfile`. The Dockerfile must:
-1. Start from a base image with the required runtime
-2. Copy in the `sandbox-api` binary (or build it from source)
-3. Expose port `8080` for the sandbox-api
-4. Set an entrypoint that starts `sandbox-api`
+Usually update for local testing:
 
-Minimal example (adapts the base-image pattern):
+- `docker-compose.yaml`
+
+Only update `README.md` for visible user-facing templates. Do not list hidden/internal images as normal templates.
+
+## Dockerfile Rules
+
+Follow the existing multi-stage pattern:
 
 ```dockerfile
-FROM ubuntu:22.04
+ARG SANDBOX_VERSION=latest
+FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y \
-    curl \
-    <your-tools> \
-    && rm -rf /var/lib/apt/lists/*
+FROM <runtime-base>
 
-# Copy sandbox-api binary (built by the multi-stage or pre-built)
-COPY sandbox-api/sandbox-api /usr/local/bin/sandbox-api
+RUN <install required runtime tools>
+
+WORKDIR /blaxel
+
+COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
 RUN chmod +x /usr/local/bin/sandbox-api
 
-# Working directory for user code
-WORKDIR /blaxel/app
-
 EXPOSE 8080
+
+ENV HOME=/blaxel
 
 ENTRYPOINT ["/usr/local/bin/sandbox-api"]
 ```
 
-Look at existing templates for reference patterns:
-- `hub/base-image/Dockerfile` — minimal baseline
-- `hub/py-app/Dockerfile` — Python with pip
-- `hub/ts-app/Dockerfile` — Node.js/TypeScript
-- `hub/expo/Dockerfile` — Expo with entrypoint script that auto-starts a dev server
+Rules:
 
-If your template needs to auto-start a service on boot, create an `entrypoint.sh` script and call it before `sandbox-api` (see `hub/expo/entrypoint.sh` for an example using `curl` to POST to `/process`).
+- Always include the `ARG SANDBOX_VERSION=latest` stage unless the image has a specific reason not to.
+- Copy `/sandbox-api` from the sandbox-api stage into `/usr/local/bin/sandbox-api`.
+- Expose `8080` for `sandbox-api`.
+- Only expose app/dev ports when they are intrinsic to that template. Do not expose dynamic app ports for platform-managed hidden images.
+- If an entrypoint script is needed, keep `sandbox-api` running as the control plane and test the real startup path.
+- Keep runtime dependencies explicit. If the runner supports `s3://`, `gs://`, or Azure Blob, install and test `rclone`.
 
----
+## template.json Rules
 
-## Step 3: Write template.json
-
-Create `hub/<template-name>/template.json`:
+Minimal shape:
 
 ```json
 {
-  "name": "<template-name>",
-  "displayName": "<Human Readable Name>",
+  "name": "<name>",
+  "displayName": "<Display Name>",
   "categories": [],
-  "description": "Short one-line description",
-  "longDescription": "Longer description explaining use cases and what's included.",
-  "url": "https://link-to-upstream-project",
-  "icon": "https://url-to-icon-image.png",
-  "memory": 4096,
+  "description": "Short description.",
+  "longDescription": "Longer description.",
+  "url": "https://github.com/blaxel-ai/sandbox",
+  "icon": "https://blaxel.ai/logo.png",
+  "memory": 2048,
   "ports": [
     {
       "name": "sandbox-api",
@@ -84,67 +92,84 @@ Create `hub/<template-name>/template.json`:
 }
 ```
 
-- `memory`: RAM in MB (`4096` = 4GB is standard; increase for heavy workloads)
-- `ports`: List all ports the template exposes. Add extra entries for app ports (e.g., 3000 for a dev server)
-- `enterprise`: Set `true` to restrict to enterprise workspaces
-- `coming_soon`: Set `true` to show the template in the UI but disable creation
+For hidden/internal images, add:
 
----
+```json
+"hidden": true
+```
 
-## Step 4: Add to docker-compose.yaml
+Port rule: put only stable ports in `template.json`. If another service creates previews with a caller-provided `runtime.port`, leave that dynamic port out of the template.
 
-Add a service entry so you can test locally:
+## GitHub Workflow
+
+Update `.github/workflows/build.yaml` every time a new hub image is added:
+
+- Add `<name>` under `on.workflow_dispatch.inputs.sandbox.options`.
+- Keep alphabetical-ish order near existing options.
+
+The automatic build matrix uses folders under `hub/`, so the directory is enough for push/tag auto-detection. The `workflow_dispatch` options list is separate and must be updated manually.
+
+## docker-compose
+
+Add a service when local build/run is useful:
 
 ```yaml
-  <template-name>:
+  <name>:
     platform: linux/amd64
     build:
       context: .
-      dockerfile: hub/<template-name>/Dockerfile
+      dockerfile: hub/<name>/Dockerfile
     env_file:
       - .env
     ports:
       - "8080:8080"
-      - "<app-port>:<app-port>"  # add any extra ports
       - "3010:3010"
 ```
 
----
+Add app ports only when they are stable template ports. Avoid dynamic platform-managed app ports.
 
-## Step 5: Build and Test Locally
+## Validation
+
+Run the cheapest structural checks first:
 
 ```bash
-# Build the image
-docker-compose build <template-name>
+jq empty hub/<name>/template.json
+find hub/<name> -maxdepth 1 -name '*.sh' -print -exec sh -n {} \;
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yaml"); puts "yaml-ok"'
+```
 
-# Start it
-docker-compose up <template-name>
+Build with an explicit platform:
 
-# Verify sandbox-api is running
+```bash
+docker build --platform linux/amd64 -t blaxel/<name>:test -f hub/<name>/Dockerfile .
+```
+
+Prefer explicit `docker build --platform linux/amd64` over `docker compose build` on Apple Silicon. Some local compose providers ignore the service platform when pulling `ghcr.io/blaxel-ai/sandbox:latest` and fail on `arm64`.
+
+If the image has a runner or entrypoint script, smoke-test it inside the built image with realistic env vars and mounted test input. Verify:
+
+- required binaries exist (`command -v <tool>`)
+- source materialization works
+- pre-start/setup hooks run in the intended order
+- the final command starts or exits as expected
+
+When feasible, start the sandbox API and check:
+
+```bash
 curl http://localhost:8080/health
-
-# Run a process inside it
 curl -X POST http://localhost:8080/process \
   -H "Content-Type: application/json" \
   -d '{"command": "echo hello", "waitForCompletion": true}'
 ```
 
----
+## Final Checklist
 
-## Step 6: Run Integration Tests Against It
-
-```bash
-cd sandbox-api/integration-tests
-API_HOST=localhost API_PORT=8080 ./run_tests.sh
-```
-
----
-
-## Checklist Before PR
-
-- [ ] `hub/<template-name>/Dockerfile` builds successfully
-- [ ] `hub/<template-name>/template.json` is valid JSON with all required fields
-- [ ] Service added to `docker-compose.yaml`
-- [ ] `curl http://localhost:8080/health` returns `200 OK`
-- [ ] Integration tests pass against the new image
-- [ ] Template listed in the root `README.md` under the Templates section
+- [ ] `hub/<name>/Dockerfile` builds with `--platform linux/amd64`.
+- [ ] `hub/<name>/template.json` is valid JSON.
+- [ ] Hidden/internal images have `"hidden": true`.
+- [ ] Dynamic app ports are not hard-coded in `Dockerfile`, `template.json`, or `docker-compose.yaml`.
+- [ ] `.github/workflows/build.yaml` includes `<name>` in `workflow_dispatch` options.
+- [ ] `docker-compose.yaml` is updated when local testing is useful.
+- [ ] Runner or entrypoint scripts are syntax-checked and smoke-tested.
+- [ ] User-facing visible templates are documented in `README.md`; hidden/internal ones are not.
+- [ ] No public action, commit, push, PR, or deploy is performed without user confirmation.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,7 @@ on:
         default: ""
         options:
           - all
+          - app-runner
           - astro
           - base-image
           - chromium

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
       - .env
     ports:
       - "8080:8080"
-      - "3000:3000"
       - "3010:3010"
 
   py-app:
@@ -29,6 +28,17 @@ services:
     build:
       context: .
       dockerfile: hub/base-image/Dockerfile
+    env_file:
+      - .env
+    ports:
+      - "8080:8080"
+      - "3010:3010"
+
+  app-runner:
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: hub/app-runner/Dockerfile
     env_file:
       - .env
     ports:

--- a/hub/app-runner/Dockerfile
+++ b/hub/app-runner/Dockerfile
@@ -1,0 +1,31 @@
+ARG SANDBOX_VERSION=latest
+FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
+
+FROM node:22-alpine
+
+RUN apk update && apk add --no-cache \
+  bash \
+  ca-certificates \
+  curl \
+  git \
+  jq \
+  openssh-client \
+  py3-pip \
+  python3 \
+  rclone \
+  wget \
+  && rm -rf /var/cache/apk/* \
+  && rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
+
+WORKDIR /blaxel
+
+COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
+COPY hub/app-runner/runner.sh /usr/local/bin/app-runner
+
+RUN chmod +x /usr/local/bin/sandbox-api /usr/local/bin/app-runner
+
+EXPOSE 8080
+
+ENV HOME=/blaxel
+
+ENTRYPOINT ["/usr/local/bin/sandbox-api"]

--- a/hub/app-runner/runner.sh
+++ b/hub/app-runner/runner.sh
@@ -1,0 +1,203 @@
+#!/bin/sh
+set -eu
+
+APP_ROOT="${APP_RUNNER_WORKDIR:-/workspace}"
+SOURCE_URI="${APP_RUNNER_SOURCE_URI:-}"
+SOURCE_TYPE="${APP_RUNNER_SOURCE_TYPE:-auto}"
+SOURCE_REF="${APP_RUNNER_SOURCE_REF:-}"
+CONTEXT_PATH="${APP_RUNNER_CONTEXT_PATH:-}"
+PRE_START_COMMAND="${APP_RUNNER_PRE_START_COMMAND:-}"
+START_COMMAND="${APP_RUNNER_START_COMMAND:-}"
+SETUP_SCRIPT_B64="${APP_RUNNER_SETUP_SCRIPT_B64:-}"
+
+case "$APP_ROOT" in
+  ""|"/"|"/bin"|"/etc"|"/usr"|"/var"|"/tmp"|"/blaxel")
+    echo "Unsafe APP_RUNNER_WORKDIR: $APP_ROOT" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "$SOURCE_URI" ]; then
+  echo "APP_RUNNER_SOURCE_URI is required" >&2
+  exit 1
+fi
+
+if [ -z "$START_COMMAND" ]; then
+  echo "APP_RUNNER_START_COMMAND is required" >&2
+  exit 1
+fi
+
+rm -rf "$APP_ROOT"
+mkdir -p "$APP_ROOT"
+SOURCE_DIR="$APP_ROOT/source"
+
+run_setup_script() {
+  if [ -z "$SETUP_SCRIPT_B64" ]; then
+    return 0
+  fi
+
+  setup_script=$(mktemp)
+  if ! printf "%s" "$SETUP_SCRIPT_B64" | base64 -d > "$setup_script"; then
+    rm -f "$setup_script"
+    echo "APP_RUNNER_SETUP_SCRIPT_B64 is not valid base64" >&2
+    exit 1
+  fi
+
+  chmod +x "$setup_script"
+  echo "Running app runner setup script..."
+  if ! (cd "$APP_ROOT" && /bin/sh "$setup_script"); then
+    rm -f "$setup_script"
+    echo "App runner setup script failed" >&2
+    exit 1
+  fi
+  rm -f "$setup_script"
+}
+
+download_https() {
+  url="$1"
+  dest="$2"
+  python3 - "$url" "$dest" <<'PY'
+import sys
+import urllib.request
+
+url, dest = sys.argv[1], sys.argv[2]
+with urllib.request.urlopen(url) as response, open(dest, "wb") as out:
+    out.write(response.read())
+PY
+}
+
+extract_or_copy() {
+  file="$1"
+  target="$2"
+  mkdir -p "$target"
+  case "$file" in
+    *.zip)
+      python3 - "$file" "$target" <<'PY'
+import os
+import sys
+import zipfile
+
+target = os.path.realpath(sys.argv[2])
+with zipfile.ZipFile(sys.argv[1]) as archive:
+    for member in archive.infolist():
+        dest = os.path.realpath(os.path.join(target, member.filename))
+        if dest != target and not dest.startswith(target + os.sep):
+            raise SystemExit(f"Unsafe archive path: {member.filename}")
+    archive.extractall(target)
+PY
+      ;;
+    *.tar|*.tar.gz|*.tgz|*.tar.bz2|*.tar.xz)
+      python3 - "$file" "$target" <<'PY'
+import os
+import sys
+import tarfile
+
+target = os.path.realpath(sys.argv[2])
+with tarfile.open(sys.argv[1]) as archive:
+    for member in archive.getmembers():
+        dest = os.path.realpath(os.path.join(target, member.name))
+        if dest != target and not dest.startswith(target + os.sep):
+            raise SystemExit(f"Unsafe archive path: {member.name}")
+    archive.extractall(target, filter="data")
+PY
+      ;;
+    *)
+      cp "$file" "$target/$(basename "$file")"
+      ;;
+  esac
+}
+
+clone_git() {
+  uri="$1"
+  target="$2"
+  if [ -n "$SOURCE_REF" ]; then
+    if git clone --depth 1 --branch "$SOURCE_REF" "$uri" "$target"; then
+      return 0
+    fi
+  fi
+  git clone "$uri" "$target"
+  if [ -n "$SOURCE_REF" ]; then
+    (cd "$target" && git checkout "$SOURCE_REF")
+  fi
+}
+
+copy_with_rclone() {
+  kind="$1"
+  uri="$2"
+  target="$3"
+  remote_path=$(printf "%s" "$uri" | sed "s|^[^:]*://||")
+  case "$kind" in
+    s3)
+      provider="${RCLONE_S3_PROVIDER:-AWS}"
+      region="${RCLONE_S3_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+      rclone copy ":s3,provider=$provider,region=$region,env_auth=true:$remote_path" "$target"
+      ;;
+    gcs)
+      rclone copy ":gcs:$remote_path" "$target"
+      ;;
+    azure|azure_blob)
+      rclone copy ":azureblob:$remote_path" "$target"
+      ;;
+    *)
+      echo "Unsupported rclone source type: $kind" >&2
+      exit 1
+      ;;
+  esac
+}
+
+run_setup_script
+
+if [ "$SOURCE_TYPE" = "auto" ]; then
+  case "$SOURCE_URI" in
+    *.git|*github.com*|*gitlab.com*) SOURCE_TYPE="git" ;;
+    s3://*) SOURCE_TYPE="s3" ;;
+    gs://*|gcs://*) SOURCE_TYPE="gcs" ;;
+    azure://*|azureblob://*|azure_blob://*) SOURCE_TYPE="azure_blob" ;;
+    https://*) SOURCE_TYPE="https" ;;
+    *)
+      echo "Unable to infer source type for $SOURCE_URI" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+case "$SOURCE_TYPE" in
+  git)
+    clone_git "$SOURCE_URI" "$SOURCE_DIR"
+    ;;
+  https)
+    download_name=$(basename "${SOURCE_URI%%\?*}")
+    if [ -z "$download_name" ]; then
+      download_name="source-download"
+    fi
+    tmp_file="$APP_ROOT/$download_name"
+    download_https "$SOURCE_URI" "$tmp_file"
+    extract_or_copy "$tmp_file" "$SOURCE_DIR"
+    ;;
+  s3|gcs|azure|azure_blob)
+    mkdir -p "$SOURCE_DIR"
+    copy_with_rclone "$SOURCE_TYPE" "$SOURCE_URI" "$SOURCE_DIR"
+    ;;
+  *)
+    echo "Unsupported source type: $SOURCE_TYPE" >&2
+    exit 1
+    ;;
+esac
+
+RUN_DIR="$SOURCE_DIR"
+if [ -n "$CONTEXT_PATH" ]; then
+  RUN_DIR="$SOURCE_DIR/$CONTEXT_PATH"
+fi
+
+if [ ! -d "$RUN_DIR" ]; then
+  echo "App context path does not exist: $RUN_DIR" >&2
+  exit 1
+fi
+
+cd "$RUN_DIR"
+
+if [ -n "$PRE_START_COMMAND" ]; then
+  /bin/sh -lc "$PRE_START_COMMAND"
+fi
+
+exec /bin/sh -lc "$START_COMMAND"

--- a/hub/app-runner/template.json
+++ b/hub/app-runner/template.json
@@ -1,0 +1,20 @@
+{
+  "name": "app-runner",
+  "displayName": "App Runner",
+  "categories": ["backend"],
+  "description": "A hidden runtime image for launching uploaded or cloned application sources.",
+  "longDescription": "The App Runner sandbox materializes app source code from git, HTTPS archives, S3, GCS, or Azure Blob storage, optionally runs a base64 setup script before source materialization, optionally runs a pre-start command after source materialization, then starts the application command on the configured port. It is intended for platform-managed app hosting flows rather than direct Hub selection.",
+  "url": "https://github.com/blaxel-ai/sandbox",
+  "icon": "https://blaxel.ai/logo.png",
+  "memory": 2048,
+  "ports": [
+    {
+      "name": "sandbox-api",
+      "target": 8080,
+      "protocol": "HTTP"
+    }
+  ],
+  "enterprise": false,
+  "coming_soon": false,
+  "hidden": true
+}


### PR DESCRIPTION
Adds a new `app-runner` hidden/internal sandbox image for platform-managed app hosting flows.

- **`hub/app-runner/Dockerfile`**: New multi-stage Dockerfile based on `node:22-alpine`, includes bash, curl, git, python3, rclone, and other utilities alongside the `sandbox-api` binary and a `runner.sh` entrypoint script.
- **`hub/app-runner/runner.sh`**: Shell script that materializes application source code from git, HTTPS archives, S3, GCS, or Azure Blob Storage; optionally runs a base64-encoded setup script and a pre-start command; then launches the configured start command.
- **`hub/app-runner/template.json`**: Template metadata with `"hidden": true` — marks this as an internal/platform-managed image not exposed in the Hub UI.
- **`.github/workflows/build.yaml`**: Adds `app-runner` to the `workflow_dispatch` sandbox options for manual CI builds.
- **`docker-compose.yaml`**: Adds an `app-runner` service for local testing and removes the unused `3000:3000` port mapping from the base service.
- **`.agents/skills/add-hub-template/SKILL.md`**: Updates the skill documentation to cover hidden/internal images, dynamic port rules, and improved validation guidance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new hidden/internal `app-runner` sandbox image that materializes application source code from git, HTTPS archives, S3, GCS, or Azure Blob; optionally runs a base64-encoded setup script and a pre-start command; then launches the configured start command. Includes Dockerfile, runner.sh entrypoint, template.json (hidden), CI workflow update, and docker-compose service.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 5a06961e3f5638f8bedfd555f507628f78ae6b20.</sup>
<!-- /MENDRAL_SUMMARY -->