### PR TITLE
Add fsEditFile MCP tool for targeted file edits

### DIFF
--- a/sandbox-api/integration-tests/tests/mcp/fs_edit_file_test.go
+++ b/sandbox-api/integration-tests/tests/mcp/fs_edit_file_test.go
@@ -1,0 +1,262 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// editFileOutput is the structured payload returned by the fsEditFile tool.
+// Defined locally so tests decode it without importing the server package.
+type editFileOutput struct {
+	Path                string `json:"path"`
+	OccurrencesReplaced int    `json:"occurrencesReplaced"`
+}
+
+// uniqueTestPath returns a /tmp path unique to this test invocation.
+func uniqueTestPath(prefix string) string {
+	return fmt.Sprintf("/tmp/fs-edit-%s-%d", prefix, time.Now().UnixNano())
+}
+
+// writeFileMCP creates a file via the fsWriteFile MCP tool.
+// permissions may be empty (server default applies) or an octal string like "640".
+func writeFileMCP(t *testing.T, session *mcp.ClientSession, path, content, permissions string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	args := map[string]any{
+		"path":    path,
+		"content": content,
+	}
+	if permissions != "" {
+		args["permissions"] = permissions
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "fsWriteFile",
+		Arguments: args,
+	})
+	require.NoError(t, err, "fsWriteFile transport error")
+	require.False(t, result.IsError, "fsWriteFile tool error: %s", textOf(result))
+}
+
+// readFileMCP returns the current content of a file via the fsReadFile MCP tool.
+func readFileMCP(t *testing.T, session *mcp.ClientSession, path string) (content string, permissions string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "fsReadFile",
+		Arguments: map[string]any{"path": path},
+	})
+	require.NoError(t, err, "fsReadFile transport error")
+	require.False(t, result.IsError, "fsReadFile tool error: %s", textOf(result))
+
+	var out struct {
+		Content     string `json:"content"`
+		Permissions string `json:"permissions"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &out), "fsReadFile response not JSON")
+	return out.Content, out.Permissions
+}
+
+// callEditFile invokes fsEditFile and returns the raw MCP result for the caller to inspect.
+func callEditFile(t *testing.T, session *mcp.ClientSession, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "fsEditFile",
+		Arguments: args,
+	})
+	require.NoError(t, err, "fsEditFile transport error")
+	return result
+}
+
+// textOf extracts the first TextContent block from a tool result. Returns "" if none.
+func textOf(result *mcp.CallToolResult) string {
+	if result == nil || len(result.Content) == 0 {
+		return ""
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		return ""
+	}
+	return tc.Text
+}
+
+// cleanup deletes a file after a test. Best-effort; ignores errors so tests don't mask failures.
+func cleanupFile(t *testing.T, session *mcp.ClientSession, path string) {
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_, _ = session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "fsDeleteFileOrDirectory",
+			Arguments: map[string]any{"path": path},
+		})
+	})
+}
+
+// --- Tests ---
+
+// TestFsEditFile_HappyPath_UniqueMatch: single occurrence replaced, file content updated,
+// structured output reports occurrencesReplaced=1.
+func TestFsEditFile_HappyPath_UniqueMatch(t *testing.T) {
+	_, session := setupMCPClient(t)
+	path := uniqueTestPath("happy")
+	cleanupFile(t, session, path)
+
+	writeFileMCP(t, session, path, "hello world\nfoo bar\n", "")
+
+	result := callEditFile(t, session, map[string]any{
+		"path":      path,
+		"oldString": "foo bar",
+		"newString": "foo BAZ",
+	})
+	require.False(t, result.IsError, "expected success, got error: %s", textOf(result))
+
+	var out editFileOutput
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &out))
+	assert.Equal(t, path, out.Path)
+	assert.Equal(t, 1, out.OccurrencesReplaced)
+
+	content, _ := readFileMCP(t, session, path)
+	assert.Equal(t, "hello world\nfoo BAZ\n", content)
+}
+
+// TestFsEditFile_ZeroMatch: oldString absent from file. Returns an error result
+// with a message that prompts the model to re-read the file.
+func TestFsEditFile_ZeroMatch(t *testing.T) {
+	_, session := setupMCPClient(t)
+	path := uniqueTestPath("zero")
+	cleanupFile(t, session, path)
+
+	writeFileMCP(t, session, path, "alpha\nbeta\ngamma\n", "")
+
+	result := callEditFile(t, session, map[string]any{
+		"path":      path,
+		"oldString": "delta",
+		"newString": "epsilon",
+	})
+	assert.True(t, result.IsError, "expected error when oldString not found")
+	assert.Contains(t, textOf(result), "not found",
+		"error message should indicate the string was not found")
+
+	// File must be unchanged.
+	content, _ := readFileMCP(t, session, path)
+	assert.Equal(t, "alpha\nbeta\ngamma\n", content)
+}
+
+// TestFsEditFile_MultipleMatches_WithoutReplaceAll: ambiguous match must error, not silently
+// pick the first occurrence. The error message names the count.
+func TestFsEditFile_MultipleMatches_WithoutReplaceAll(t *testing.T) {
+	_, session := setupMCPClient(t)
+	path := uniqueTestPath("ambiguous")
+	cleanupFile(t, session, path)
+
+	writeFileMCP(t, session, path, "x = 1\nx = 1\nx = 1\n", "")
+
+	result := callEditFile(t, session, map[string]any{
+		"path":      path,
+		"oldString": "x = 1",
+		"newString": "x = 2",
+	})
+	assert.True(t, result.IsError, "expected error on multiple matches without replaceAll")
+	assert.Contains(t, textOf(result), "3",
+		"error message should report the number of matches")
+
+	// File must be unchanged.
+	content, _ := readFileMCP(t, session, path)
+	assert.Equal(t, "x = 1\nx = 1\nx = 1\n", content)
+}
+
+// TestFsEditFile_MultipleMatches_ReplaceAll: with replaceAll=true, every occurrence is replaced
+// and occurrencesReplaced equals the original match count.
+func TestFsEditFile_MultipleMatches_ReplaceAll(t *testing.T) {
+	_, session := setupMCPClient(t)
+	path := uniqueTestPath("replaceall")
+	cleanupFile(t, session, path)
+
+	writeFileMCP(t, session, path, "x = 1\nx = 1\nx = 1\n", "")
+
+	result := callEditFile(t, session, map[string]any{
+		"path":       path,
+		"oldString":  "x = 1",
+		"newString":  "x = 2",
+		"replaceAll": true,
+	})
+	require.False(t, result.IsError, "expected success with replaceAll, got: %s", textOf(result))
+
+	var out editFileOutput
+	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &out))
+	assert.Equal(t, 3, out.OccurrencesReplaced)
+
+	content, _ := readFileMCP(t, session, path)
+	assert.Equal(t, "x = 2\nx = 2\nx = 2\n", content)
+}
+
+// TestFsEditFile_IdenticalStrings: oldString == newString is a no-op the caller didn't mean.
+// Should fail loudly rather than silently rewrite the file.
+func TestFsEditFile_IdenticalStrings(t *testing.T) {
+	_, session := setupMCPClient(t)
+	path := uniqueTestPath("identical")
+	cleanupFile(t, session, path)
+
+	writeFileMCP(t, session, path, "content\n", "")
+
+	result := callEditFile(t, session, map[string]any{
+		"path":      path,
+		"oldString": "content",
+		"newString": "content",
+	})
+	assert.True(t, result.IsError, "expected error when oldString == newString")
+	assert.Contains(t, textOf(result), "identical",
+		"error message should mention that the strings are identical")
+}
+
+// TestFsEditFile_EmptyOldString: empty oldString is invalid (would match everywhere, no useful semantics).
+func TestFsEditFile_EmptyOldString(t *testing.T) {
+	_, session := setupMCPClient(t)
+	path := uniqueTestPath("empty")
+	cleanupFile(t, session, path)
+
+	writeFileMCP(t, session, path, "content\n", "")
+
+	result := callEditFile(t, session, map[string]any{
+		"path":      path,
+		"oldString": "",
+		"newString": "anything",
+	})
+	assert.True(t, result.IsError, "expected error when oldString is empty")
+}
+
+// TestFsEditFile_PreservesPermissions: editing must not change the file's mode bits.
+// fsWriteFile defaults to 0644, so we explicitly set 0640 on the source file.
+func TestFsEditFile_PreservesPermissions(t *testing.T) {
+	_, session := setupMCPClient(t)
+	path := uniqueTestPath("perms")
+	cleanupFile(t, session, path)
+
+	writeFileMCP(t, session, path, "before\n", "640")
+	_, modeBefore := readFileMCP(t, session, path)
+	require.Equal(t, "640", modeBefore, "test precondition: file should be 0640")
+
+	result := callEditFile(t, session, map[string]any{
+		"path":      path,
+		"oldString": "before",
+		"newString": "after",
+	})
+	require.False(t, result.IsError, "edit failed: %s", textOf(result))
+
+	_, modeAfter := readFileMCP(t, session, path)
+	assert.Equal(t, modeBefore, modeAfter, "fsEditFile must preserve the file mode")
+}

--- a/sandbox-api/integration-tests/tests/mcp/fs_edit_file_test.go
+++ b/sandbox-api/integration-tests/tests/mcp/fs_edit_file_test.go
@@ -25,30 +25,24 @@ func uniqueTestPath(prefix string) string {
 }
 
 // writeFileMCP creates a file via the fsWriteFile MCP tool.
-// permissions may be empty (server default applies) or an octal string like "640".
-func writeFileMCP(t *testing.T, session *mcp.ClientSession, path, content, permissions string) {
+func writeFileMCP(t *testing.T, session *mcp.ClientSession, path, content string) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	args := map[string]any{
-		"path":    path,
-		"content": content,
-	}
-	if permissions != "" {
-		args["permissions"] = permissions
-	}
-
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{
-		Name:      "fsWriteFile",
-		Arguments: args,
+		Name: "fsWriteFile",
+		Arguments: map[string]any{
+			"path":    path,
+			"content": content,
+		},
 	})
 	require.NoError(t, err, "fsWriteFile transport error")
 	require.False(t, result.IsError, "fsWriteFile tool error: %s", textOf(result))
 }
 
 // readFileMCP returns the current content of a file via the fsReadFile MCP tool.
-func readFileMCP(t *testing.T, session *mcp.ClientSession, path string) (content string, permissions string) {
+func readFileMCP(t *testing.T, session *mcp.ClientSession, path string) string {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -61,11 +55,10 @@ func readFileMCP(t *testing.T, session *mcp.ClientSession, path string) (content
 	require.False(t, result.IsError, "fsReadFile tool error: %s", textOf(result))
 
 	var out struct {
-		Content     string `json:"content"`
-		Permissions string `json:"permissions"`
+		Content string `json:"content"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &out), "fsReadFile response not JSON")
-	return out.Content, out.Permissions
+	return out.Content
 }
 
 // callEditFile invokes fsEditFile and returns the raw MCP result for the caller to inspect.
@@ -115,7 +108,7 @@ func TestFsEditFile_HappyPath_UniqueMatch(t *testing.T) {
 	path := uniqueTestPath("happy")
 	cleanupFile(t, session, path)
 
-	writeFileMCP(t, session, path, "hello world\nfoo bar\n", "")
+	writeFileMCP(t, session, path, "hello world\nfoo bar\n")
 
 	result := callEditFile(t, session, map[string]any{
 		"path":      path,
@@ -129,7 +122,7 @@ func TestFsEditFile_HappyPath_UniqueMatch(t *testing.T) {
 	assert.Equal(t, path, out.Path)
 	assert.Equal(t, 1, out.OccurrencesReplaced)
 
-	content, _ := readFileMCP(t, session, path)
+	content := readFileMCP(t, session, path)
 	assert.Equal(t, "hello world\nfoo BAZ\n", content)
 }
 
@@ -140,7 +133,7 @@ func TestFsEditFile_ZeroMatch(t *testing.T) {
 	path := uniqueTestPath("zero")
 	cleanupFile(t, session, path)
 
-	writeFileMCP(t, session, path, "alpha\nbeta\ngamma\n", "")
+	writeFileMCP(t, session, path, "alpha\nbeta\ngamma\n")
 
 	result := callEditFile(t, session, map[string]any{
 		"path":      path,
@@ -152,7 +145,7 @@ func TestFsEditFile_ZeroMatch(t *testing.T) {
 		"error message should indicate the string was not found")
 
 	// File must be unchanged.
-	content, _ := readFileMCP(t, session, path)
+	content := readFileMCP(t, session, path)
 	assert.Equal(t, "alpha\nbeta\ngamma\n", content)
 }
 
@@ -163,7 +156,7 @@ func TestFsEditFile_MultipleMatches_WithoutReplaceAll(t *testing.T) {
 	path := uniqueTestPath("ambiguous")
 	cleanupFile(t, session, path)
 
-	writeFileMCP(t, session, path, "x = 1\nx = 1\nx = 1\n", "")
+	writeFileMCP(t, session, path, "x = 1\nx = 1\nx = 1\n")
 
 	result := callEditFile(t, session, map[string]any{
 		"path":      path,
@@ -175,7 +168,7 @@ func TestFsEditFile_MultipleMatches_WithoutReplaceAll(t *testing.T) {
 		"error message should report the number of matches")
 
 	// File must be unchanged.
-	content, _ := readFileMCP(t, session, path)
+	content := readFileMCP(t, session, path)
 	assert.Equal(t, "x = 1\nx = 1\nx = 1\n", content)
 }
 
@@ -186,7 +179,7 @@ func TestFsEditFile_MultipleMatches_ReplaceAll(t *testing.T) {
 	path := uniqueTestPath("replaceall")
 	cleanupFile(t, session, path)
 
-	writeFileMCP(t, session, path, "x = 1\nx = 1\nx = 1\n", "")
+	writeFileMCP(t, session, path, "x = 1\nx = 1\nx = 1\n")
 
 	result := callEditFile(t, session, map[string]any{
 		"path":       path,
@@ -200,7 +193,7 @@ func TestFsEditFile_MultipleMatches_ReplaceAll(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(textOf(result)), &out))
 	assert.Equal(t, 3, out.OccurrencesReplaced)
 
-	content, _ := readFileMCP(t, session, path)
+	content := readFileMCP(t, session, path)
 	assert.Equal(t, "x = 2\nx = 2\nx = 2\n", content)
 }
 
@@ -211,7 +204,7 @@ func TestFsEditFile_IdenticalStrings(t *testing.T) {
 	path := uniqueTestPath("identical")
 	cleanupFile(t, session, path)
 
-	writeFileMCP(t, session, path, "content\n", "")
+	writeFileMCP(t, session, path, "content\n")
 
 	result := callEditFile(t, session, map[string]any{
 		"path":      path,
@@ -229,7 +222,7 @@ func TestFsEditFile_EmptyOldString(t *testing.T) {
 	path := uniqueTestPath("empty")
 	cleanupFile(t, session, path)
 
-	writeFileMCP(t, session, path, "content\n", "")
+	writeFileMCP(t, session, path, "content\n")
 
 	result := callEditFile(t, session, map[string]any{
 		"path":      path,
@@ -237,26 +230,4 @@ func TestFsEditFile_EmptyOldString(t *testing.T) {
 		"newString": "anything",
 	})
 	assert.True(t, result.IsError, "expected error when oldString is empty")
-}
-
-// TestFsEditFile_PreservesPermissions: editing must not change the file's mode bits.
-// fsWriteFile defaults to 0644, so we explicitly set 0640 on the source file.
-func TestFsEditFile_PreservesPermissions(t *testing.T) {
-	_, session := setupMCPClient(t)
-	path := uniqueTestPath("perms")
-	cleanupFile(t, session, path)
-
-	writeFileMCP(t, session, path, "before\n", "640")
-	_, modeBefore := readFileMCP(t, session, path)
-	require.Equal(t, "640", modeBefore, "test precondition: file should be 0640")
-
-	result := callEditFile(t, session, map[string]any{
-		"path":      path,
-		"oldString": "before",
-		"newString": "after",
-	})
-	require.False(t, result.IsError, "edit failed: %s", textOf(result))
-
-	_, modeAfter := readFileMCP(t, session, path)
-	assert.Equal(t, modeBefore, modeAfter, "fsEditFile must preserve the file mode")
 }

--- a/sandbox-api/integration-tests/tests/mcp/mcp_client_test.go
+++ b/sandbox-api/integration-tests/tests/mcp/mcp_client_test.go
@@ -95,6 +95,7 @@ func TestMCPClientListTools(t *testing.T) {
 		"fsListDirectory",
 		"fsReadFile",
 		"fsWriteFile",
+		"fsEditFile",
 		"fsDeleteFileOrDirectory",
 		"codegenFileSearch",
 		"codegenCodebaseSearch",

--- a/sandbox-api/src/mcp/filesystem.go
+++ b/sandbox-api/src/mcp/filesystem.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/blaxel-ai/sandbox-api/src/handler/filesystem"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -61,6 +62,18 @@ type DeleteFileInput struct {
 type DeleteFileOutput struct {
 	Path    string `json:"path"`
 	Message string `json:"message"`
+}
+
+type FsEditFileInput struct {
+	Path       string `json:"path" jsonschema:"Path to the file to edit"`
+	OldString  string `json:"oldString" jsonschema:"Exact text to replace. Must be non-empty. Must appear exactly once in the file unless replaceAll is true."`
+	NewString  string `json:"newString" jsonschema:"Replacement text. Must differ from oldString. Use an empty string to delete the matched text."`
+	ReplaceAll *bool  `json:"replaceAll,omitempty" jsonschema:"Replace every occurrence of oldString (default: false)"`
+}
+
+type FsEditFileOutput struct {
+	Path                string `json:"path"`
+	OccurrencesReplaced int    `json:"occurrencesReplaced"`
 }
 
 // registerFileSystemTools registers filesystem-related tools
@@ -154,6 +167,57 @@ func (s *Server) registerFileSystemTools() error {
 				Message: "File created/updated successfully",
 			}, nil
 		}
+	}))
+
+	// Edit file (deterministic search/replace)
+	mcp.AddTool(s.mcpServer, &mcp.Tool{
+		Name: "fsEditFile",
+		Description: "Make a targeted string-replace edit to an existing file. " +
+			"Prefer this over fsWriteFile for any change to a file that already exists. " +
+			"oldString must appear exactly once unless replaceAll is true; include enough " +
+			"surrounding context (whitespace, neighbouring lines) to make the match unambiguous.",
+	}, LogToolCall("fsEditFile", func(ctx context.Context, req *mcp.CallToolRequest, input FsEditFileInput) (*mcp.CallToolResult, FsEditFileOutput, error) {
+		if input.OldString == "" {
+			return nil, FsEditFileOutput{}, fmt.Errorf("oldString must be non-empty")
+		}
+		if input.OldString == input.NewString {
+			return nil, FsEditFileOutput{}, fmt.Errorf("oldString and newString are identical")
+		}
+		replaceAll := input.ReplaceAll != nil && *input.ReplaceAll
+
+		file, err := s.handlers.FileSystem.ReadFile(input.Path)
+		if err != nil {
+			return nil, FsEditFileOutput{}, fmt.Errorf("failed to read %s: %w", input.Path, err)
+		}
+
+		content := string(file.Content)
+		occurrences := strings.Count(content, input.OldString)
+		if occurrences == 0 {
+			return nil, FsEditFileOutput{}, fmt.Errorf(
+				"oldString not found in %s. Re-read the file and retry — its contents may have changed since you last read it",
+				input.Path)
+		}
+		if occurrences > 1 && !replaceAll {
+			return nil, FsEditFileOutput{}, fmt.Errorf(
+				"oldString matches %d locations in %s; add more surrounding context to make the match unique, or set replaceAll=true",
+				occurrences, input.Path)
+		}
+
+		var updated string
+		if replaceAll {
+			updated = strings.ReplaceAll(content, input.OldString, input.NewString)
+		} else {
+			updated = strings.Replace(content, input.OldString, input.NewString, 1)
+		}
+
+		if err := s.handlers.FileSystem.WriteFile(input.Path, []byte(updated), file.Permissions); err != nil {
+			return nil, FsEditFileOutput{}, fmt.Errorf("failed to write %s: %w", input.Path, err)
+		}
+
+		return nil, FsEditFileOutput{
+			Path:                file.Path,
+			OccurrencesReplaced: occurrences,
+		}, nil
 	}))
 
 	// Delete file or directory


### PR DESCRIPTION
This PR adds `fsEditFile` which follows Claude Code's `Edit` shape: `fsEditFile(path: str, oldString: str, newString: str, replaceAll: bool)`.

**Why ?**
The sandbox MCP exposes filesystem tools like `fsReadFile`,
`fsWriteFile`, `fsListDirectory` and `fsDeleteFileOrDirectory`. Editing
files is a core operation for any AI agent driving a sandbox, **but there is
no dedicated `fsEditFile`**. Today, agents have two options:

1. Rewrite the whole file via `fsWriteFile` for every change. This is
   token-intensive, expensive and slow, especially on larger files where
   most of the content has to be re-emitted verbatim just to alter a few
   lines.
2. Use the `codegen*` tools, which require an external LLM API key
   (Morph or Relace) and introduce a separate paid dependency for every
   edit.


**Docs follow-up**

- Update https://docs.blaxel.ai/Sandboxes/MCP#filesystem-operations to add `fsEditFile` to the filesystem operations list.
- Update https://docs.blaxel.ai/Sandboxes/Codegen-tools: the docs currently say "Traditional code generation requires generating the entire files every time", but Claude Code has used find/replace edits for a long time. The docs should recommend `fsEditFile` for normal file edits.