### PR TITLE
fix(process): preserve env on restart and support unlimited maxRestarts

### DIFF
--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -2429,6 +2429,7 @@ const docTemplate = `{
                     "example": false
                 },
                 "maxRestarts": {
+                    "description": "Maximum number of restarts on failure. Set to a negative value (e.g. -1) for unlimited restarts.",
                     "type": "integer",
                     "example": 3
                 },

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -1941,6 +1941,7 @@ components:
           example: false
           type: boolean
         maxRestarts:
+          description: Maximum number of restarts on failure. Set to a negative value (e.g. -1) for unlimited restarts.
           example: 3
           type: integer
         name:

--- a/sandbox-api/integration-tests/tests/process/process_test.go
+++ b/sandbox-api/integration-tests/tests/process/process_test.go
@@ -795,6 +795,97 @@ func TestProcessRestartOnFailureEventualSuccess(t *testing.T) {
 	}
 }
 
+// TestProcessRestartPreservesEnvironment verifies that custom environment
+// variables provided at start are reused when the process is restarted on failure.
+func TestProcessRestartPreservesEnvironment(t *testing.T) {
+	t.Log("=== Testing environment is preserved across restart on failure ===")
+
+	counterFile := "/tmp/test_restart_env_counter.txt"
+	setupCmd := "rm -f " + counterFile
+	resp, err := common.MakeRequest(http.MethodPost, "/process", map[string]interface{}{
+		"command":           setupCmd,
+		"waitForCompletion": true,
+	})
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Prints the custom env var on every attempt, fails the first time, then succeeds.
+	processRequest := map[string]interface{}{
+		"name":              fmt.Sprintf("test-restart-env-%d", time.Now().UnixNano()),
+		"command":           "printf 'VAR=[%s]\\n' \"$MY_RESTART_VAR\"; if [ ! -f " + counterFile + " ]; then echo 1 > " + counterFile + "; exit 1; else rm -f " + counterFile + "; exit 0; fi",
+		"cwd":               "/",
+		"env":               map[string]string{"MY_RESTART_VAR": "preserved_value_42"},
+		"waitForCompletion": true,
+		"restartOnFailure":  true,
+		"maxRestarts":       3,
+		"timeout":           15,
+	}
+
+	resp, err = common.MakeRequest(http.MethodPost, "/process", processRequest)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "Process creation should succeed")
+
+	var processResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&processResponse)
+	require.NoError(t, err)
+
+	assert.Equal(t, "completed", processResponse["status"], "Process should eventually complete")
+	assert.Equal(t, float64(1), processResponse["restartCount"], "Process should have restarted once")
+
+	logs, ok := processResponse["logs"].(string)
+	require.True(t, ok, "Response should contain logs")
+	t.Logf("Process logs:\n%s", logs)
+	// The custom env var must survive the restart: present on both runs, never empty.
+	occurrences := strings.Count(logs, "VAR=[preserved_value_42]")
+	assert.Equal(t, 2, occurrences, "Custom env var should be present on both initial run and restart")
+	assert.NotContains(t, logs, "VAR=[]", "Custom env var must not be lost on restart")
+}
+
+// TestProcessUnlimitedRestarts verifies that a negative maxRestarts allows
+// the process to keep restarting until it eventually succeeds.
+func TestProcessUnlimitedRestarts(t *testing.T) {
+	t.Log("=== Testing unlimited restarts with negative maxRestarts ===")
+
+	counterFile := "/tmp/test_unlimited_restart_counter.txt"
+	setupCmd := "rm -f " + counterFile + " && echo 0 > " + counterFile
+	resp, err := common.MakeRequest(http.MethodPost, "/process", map[string]interface{}{
+		"command":           setupCmd,
+		"waitForCompletion": true,
+	})
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Fails 3 times then succeeds. maxRestarts is -1 (unlimited).
+	processRequest := map[string]interface{}{
+		"name":              fmt.Sprintf("test-unlimited-restart-%d", time.Now().UnixNano()),
+		"command":           "COUNT=$(cat " + counterFile + "); NEW_COUNT=$((COUNT + 1)); echo $NEW_COUNT > " + counterFile + "; echo \"Attempt $NEW_COUNT\"; if [ $NEW_COUNT -lt 4 ]; then exit 1; else exit 0; fi",
+		"cwd":               "/",
+		"waitForCompletion": true,
+		"restartOnFailure":  true,
+		"maxRestarts":       -1,
+		"timeout":           20,
+	}
+
+	resp, err = common.MakeRequest(http.MethodPost, "/process", processRequest)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "Process creation should succeed")
+
+	var processResponse map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&processResponse)
+	require.NoError(t, err)
+
+	assert.Equal(t, "completed", processResponse["status"], "Process should eventually complete")
+	assert.Equal(t, float64(3), processResponse["restartCount"], "Process should have restarted 3 times before succeeding")
+
+	if logs, ok := processResponse["logs"].(string); ok {
+		t.Logf("Process logs:\n%s", logs)
+		assert.Contains(t, logs, "Attempting restart 1/unlimited", "Logs should show the unlimited restart label")
+		assert.Contains(t, logs, "Attempt 4", "Process should have reached the successful attempt")
+	}
+}
+
 // TestProcessRestartPIDStaysTheSame tests that PIDs remain constant across restarts
 func TestProcessRestartPIDStaysTheSame(t *testing.T) {
 	t.Log("=== Testing PID stability across restarts ===")

--- a/sandbox-api/src/handler/process.go
+++ b/sandbox-api/src/handler/process.go
@@ -55,7 +55,7 @@ type ProcessRequest struct {
 	Timeout           *int              `json:"timeout,omitempty" example:"30"` // Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).
 	WaitForPorts      []int             `json:"waitForPorts" example:"3000,8080"`
 	RestartOnFailure  bool              `json:"restartOnFailure" example:"true"`
-	MaxRestarts       int               `json:"maxRestarts" example:"3"`
+	MaxRestarts       int               `json:"maxRestarts" example:"3"`   // Maximum number of restarts on failure. Set to a negative value (e.g. -1) for unlimited restarts.
 	KeepAlive         bool              `json:"keepAlive" example:"false"` // Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.
 } // @name ProcessRequest
 

--- a/sandbox-api/src/handler/process/process.go
+++ b/sandbox-api/src/handler/process/process.go
@@ -77,7 +77,7 @@ type ProcessInfo struct {
 	ExitCode         int                     `json:"exitCode"`
 	Status           constants.ProcessStatus `json:"status"`
 	WorkingDir       string                  `json:"workingDir"`
-	Env              []string                `json:"-"` // Resolved environment (system + custom) used to (re)start the process
+	Env              map[string]string       `json:"-"` // Custom env vars provided at start, reused (re-merged with os.Environ()) on restart
 	Logs             *string                 `json:"logs"`
 	Stdout           *string                 `json:"stdout"`
 	Stderr           *string                 `json:"stderr"`
@@ -132,6 +132,38 @@ func restartLimitLabel(maxRestarts int) string {
 		return "unlimited"
 	}
 	return strconv.Itoa(maxRestarts)
+}
+
+// buildProcessEnv merges the current system environment with the caller's
+// custom environment variables, letting custom vars override system ones.
+// The system environment is read fresh from os.Environ() so only the custom
+// vars need to be stored/persisted for a later restart.
+func buildProcessEnv(custom map[string]string) []string {
+	systemEnv := os.Environ()
+
+	// Track which keys the custom env overrides.
+	overrides := make(map[string]bool, len(custom))
+	for k := range custom {
+		overrides[k] = true
+	}
+
+	finalEnv := make([]string, 0, len(systemEnv)+len(custom))
+
+	// Keep system vars that are not being overridden.
+	for _, envVar := range systemEnv {
+		if idx := strings.IndexByte(envVar, '='); idx > 0 {
+			if !overrides[envVar[:idx]] {
+				finalEnv = append(finalEnv, envVar)
+			}
+		}
+	}
+
+	// Custom vars take priority.
+	for k, v := range custom {
+		finalEnv = append(finalEnv, k+"="+v)
+	}
+
+	return finalEnv
 }
 
 // getLogFilePaths returns the log file paths for a process (stdout, stderr, combined)
@@ -211,36 +243,7 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 		Setpgid: true,
 	}
 
-	// Start with system environment
-	systemEnv := os.Environ()
-
-	// Create a map to track which env vars we're overriding
-	envOverrides := make(map[string]bool)
-	for k := range env {
-		envOverrides[k] = true
-	}
-
-	// Build the final environment
-	finalEnv := make([]string, 0, len(systemEnv)+len(env))
-
-	// Add system environment variables that are not being overridden
-	for _, envVar := range systemEnv {
-		// Find the key part (everything before the first '=')
-		idx := strings.IndexByte(envVar, '=')
-		if idx > 0 {
-			key := envVar[:idx]
-			if !envOverrides[key] {
-				finalEnv = append(finalEnv, envVar)
-			}
-		}
-	}
-
-	// Add all custom environment variables (these take priority)
-	for k, v := range env {
-		finalEnv = append(finalEnv, k+"="+v)
-	}
-
-	cmd.Env = finalEnv
+	cmd.Env = buildProcessEnv(env)
 
 	// Ensure log directory exists
 	if err := ensureLogDir(); err != nil {
@@ -275,7 +278,7 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 		CompletedAt:      nil,
 		Status:           StatusRunning,
 		WorkingDir:       workingDir,
-		Env:              finalEnv,
+		Env:              env,
 		RestartOnFailure: restartOnFailure,
 		MaxRestarts:      maxRestarts,
 		RestartCount:     0,
@@ -661,14 +664,10 @@ func (pm *ProcessManager) restartProcess(oldProcess *ProcessInfo, callback func(
 		Setpgid: true,
 	}
 
-	// Reuse the exact environment (system + custom vars) resolved at the
-	// original start. Falling back to os.Environ() would drop any custom env
-	// vars the caller passed when first starting the process.
-	if oldProcess.Env != nil {
-		cmd.Env = oldProcess.Env
-	} else {
-		cmd.Env = os.Environ()
-	}
+	// Re-merge the custom env vars provided at the original start with the
+	// current system environment. Using os.Environ() alone here would drop any
+	// custom env vars the caller passed when first starting the process.
+	cmd.Env = buildProcessEnv(oldProcess.Env)
 
 	// Open log files for appending - child writes directly to files
 	stdoutFile, err := os.OpenFile(oldProcess.StdoutFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)

--- a/sandbox-api/src/handler/process/process.go
+++ b/sandbox-api/src/handler/process/process.go
@@ -77,6 +77,7 @@ type ProcessInfo struct {
 	ExitCode         int                     `json:"exitCode"`
 	Status           constants.ProcessStatus `json:"status"`
 	WorkingDir       string                  `json:"workingDir"`
+	Env              []string                `json:"-"` // Resolved environment (system + custom) used to (re)start the process
 	Logs             *string                 `json:"logs"`
 	Stdout           *string                 `json:"stdout"`
 	Stderr           *string                 `json:"stderr"`
@@ -115,6 +116,22 @@ func init() {
 	if v := os.Getenv("SANDBOX_DISABLE_PROCESS_LOGGING"); v == "true" || v == "1" {
 		disableProcessLogging = true
 	}
+}
+
+// shouldRestart reports whether a failed process is eligible for another
+// restart attempt. A negative MaxRestarts means unlimited restarts.
+func shouldRestart(p *ProcessInfo) bool {
+	return p.Status == StatusFailed && p.RestartOnFailure &&
+		(p.MaxRestarts < 0 || p.RestartCount < p.MaxRestarts)
+}
+
+// restartLimitLabel renders the max-restarts part of a log message,
+// showing "unlimited" when MaxRestarts is negative.
+func restartLimitLabel(maxRestarts int) string {
+	if maxRestarts < 0 {
+		return "unlimited"
+	}
+	return strconv.Itoa(maxRestarts)
 }
 
 // getLogFilePaths returns the log file paths for a process (stdout, stderr, combined)
@@ -258,6 +275,7 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 		CompletedAt:      nil,
 		Status:           StatusRunning,
 		WorkingDir:       workingDir,
+		Env:              finalEnv,
 		RestartOnFailure: restartOnFailure,
 		MaxRestarts:      maxRestarts,
 		RestartCount:     0,
@@ -385,10 +403,10 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 		}
 
 		// Check if we should restart on failure
-		if process.Status == StatusFailed && process.RestartOnFailure && process.RestartCount < process.MaxRestarts {
+		if shouldRestart(process) {
 			// Log the failure and restart attempt
-			restartMsg := fmt.Sprintf("\n[Process failed with exit code %d. Attempting restart %d/%d...]\n",
-				process.ExitCode, process.RestartCount+1, process.MaxRestarts)
+			restartMsg := fmt.Sprintf("\n[Process failed with exit code %d. Attempting restart %d/%s...]\n",
+				process.ExitCode, process.RestartCount+1, restartLimitLabel(process.MaxRestarts))
 
 			process.logLock.Lock()
 			process.stdout.WriteString(restartMsg)
@@ -643,8 +661,14 @@ func (pm *ProcessManager) restartProcess(oldProcess *ProcessInfo, callback func(
 		Setpgid: true,
 	}
 
-	// Use the same environment as the original process
-	cmd.Env = os.Environ()
+	// Reuse the exact environment (system + custom vars) resolved at the
+	// original start. Falling back to os.Environ() would drop any custom env
+	// vars the caller passed when first starting the process.
+	if oldProcess.Env != nil {
+		cmd.Env = oldProcess.Env
+	} else {
+		cmd.Env = os.Environ()
+	}
 
 	// Open log files for appending - child writes directly to files
 	stdoutFile, err := os.OpenFile(oldProcess.StdoutFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -761,10 +785,10 @@ func (pm *ProcessManager) restartProcess(oldProcess *ProcessInfo, callback func(
 		}
 
 		// Check if we should restart again on failure
-		if oldProcess.Status == StatusFailed && oldProcess.RestartOnFailure && oldProcess.RestartCount < oldProcess.MaxRestarts {
+		if shouldRestart(oldProcess) {
 			// Log the failure and restart attempt
-			restartMsg := fmt.Sprintf("\n[Process failed with exit code %d. Attempting restart %d/%d...]\n",
-				oldProcess.ExitCode, oldProcess.RestartCount+1, oldProcess.MaxRestarts)
+			restartMsg := fmt.Sprintf("\n[Process failed with exit code %d. Attempting restart %d/%s...]\n",
+				oldProcess.ExitCode, oldProcess.RestartCount+1, restartLimitLabel(oldProcess.MaxRestarts))
 
 			oldProcess.logLock.Lock()
 			oldProcess.stdout.WriteString(restartMsg)

--- a/sandbox-api/src/handler/process/process_test.go
+++ b/sandbox-api/src/handler/process/process_test.go
@@ -3,6 +3,7 @@ package process
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -603,6 +604,98 @@ func TestProcessRestartOnFailure(t *testing.T) {
 			}
 		case <-time.After(10 * time.Second):
 			t.Fatal("Timeout waiting for process to complete with restarts")
+		}
+	})
+
+	t.Run("RestartPreservesEnvironment", func(t *testing.T) {
+		// The original environment (including custom env vars) must be reused
+		// when a process is restarted on failure. The command prints a custom
+		// env var on every attempt, fails the first time, then succeeds.
+		counterFile := "/tmp/restart_env_counter"
+		_ = os.Remove(counterFile)
+		command := `printf "VAR=[%s]\n" "$MY_RESTART_VAR"; if [ ! -f ` + counterFile + ` ]; then echo 1 > ` + counterFile + `; exit 1; else rm -f ` + counterFile + `; exit 0; fi`
+
+		env := map[string]string{"MY_RESTART_VAR": "preserved_value_42"}
+
+		completionChan := make(chan *ProcessInfo, 1)
+
+		pid, err := pm.StartProcess(command, "", env, true, 3, false, 0, func(process *ProcessInfo) {
+			completionChan <- process
+		})
+		if err != nil {
+			t.Fatalf("Error starting process: %v", err)
+		}
+		t.Logf("Started process with PID: %s", pid)
+
+		select {
+		case process := <-completionChan:
+			if process.Status != StatusCompleted {
+				t.Errorf("Expected process to complete successfully, got status: %s", process.Status)
+			}
+			if process.RestartCount != 1 {
+				t.Errorf("Expected 1 restart, got: %d", process.RestartCount)
+			}
+
+			logs, err := pm.GetProcessOutput(process.PID)
+			if err != nil {
+				t.Fatalf("Error getting process output: %v", err)
+			}
+
+			// The custom env var must be present on BOTH the initial run and
+			// the restarted run. Before the fix, the restart used os.Environ()
+			// and the second occurrence would be empty (VAR=[]).
+			occurrences := strings.Count(logs.Stdout, "VAR=[preserved_value_42]")
+			if occurrences != 2 {
+				t.Errorf("Expected custom env var to survive restart (2 occurrences), got %d. Stdout:\n%s", occurrences, logs.Stdout)
+			}
+			if strings.Contains(logs.Stdout, "VAR=[]") {
+				t.Errorf("Custom env var was lost on restart (found empty VAR=[]). Stdout:\n%s", logs.Stdout)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("Timeout waiting for process to complete with restarts")
+		}
+	})
+
+	t.Run("UnlimitedRestartsWithNegativeMax", func(t *testing.T) {
+		// A negative maxRestarts means unlimited restarts. The command fails
+		// 3 times then succeeds, which is more than any small positive cap would
+		// be needed for, but the point is that a negative value never blocks.
+		counterFile := "/tmp/restart_unlimited_counter"
+		_ = os.Remove(counterFile)
+		command := `if [ ! -f ` + counterFile + ` ]; then echo 1 > ` + counterFile + `; else count=$(cat ` + counterFile + `); echo $((count + 1)) > ` + counterFile + `; fi; count=$(cat ` + counterFile + `); echo "Attempt $count"; if [ $count -lt 4 ]; then exit 1; else rm -f ` + counterFile + `; exit 0; fi`
+
+		completionChan := make(chan *ProcessInfo, 1)
+
+		pid, err := pm.StartProcess(command, "", nil, true, -1, false, 0, func(process *ProcessInfo) {
+			completionChan <- process
+		})
+		if err != nil {
+			t.Fatalf("Error starting process: %v", err)
+		}
+		t.Logf("Started process with PID: %s", pid)
+
+		select {
+		case process := <-completionChan:
+			if process.Status != StatusCompleted {
+				t.Errorf("Expected process to complete successfully, got status: %s", process.Status)
+			}
+			if process.RestartCount != 3 {
+				t.Errorf("Expected 3 restarts before success, got: %d", process.RestartCount)
+			}
+
+			logs, err := pm.GetProcessOutput(process.PID)
+			if err != nil {
+				t.Fatalf("Error getting process output: %v", err)
+			}
+			// The "unlimited" label should appear in the restart message.
+			if !strings.Contains(logs.Stdout, "Attempting restart 1/unlimited") {
+				t.Errorf("Expected 'unlimited' restart label in logs. Stdout:\n%s", logs.Stdout)
+			}
+			if !strings.Contains(logs.Stdout, "Attempt 4") {
+				t.Errorf("Expected to reach 'Attempt 4'. Stdout:\n%s", logs.Stdout)
+			}
+		case <-time.After(15 * time.Second):
+			t.Fatal("Timeout waiting for process to complete with unlimited restarts")
 		}
 	})
 

--- a/sandbox-api/src/handler/process/process_test.go
+++ b/sandbox-api/src/handler/process/process_test.go
@@ -10,6 +10,18 @@ import (
 	"time"
 )
 
+// waitForProcessDone blocks until the process completion signal fires or the
+// timeout elapses. It makes post-completion assertions deterministic instead of
+// relying on a fixed sleep, which is racy under load.
+func waitForProcessDone(t *testing.T, done <-chan struct{}, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("Timeout waiting for process to complete")
+	}
+}
+
 // TestProcessManagerIntegration tests the complete functionality of the process manager
 // This is an integration test that verifies that real processes can be started, monitored, and stopped
 func TestProcessManagerIntegrationWithPID(t *testing.T) {
@@ -66,16 +78,17 @@ func TestProcessManagerIntegrationWithPID(t *testing.T) {
 	// Test process with output
 	t.Run("ProcessWithOutput", func(t *testing.T) {
 		expectedOutput := "Hello, Process Manager!"
+		done := make(chan struct{})
 		echoPID, err := pm.StartProcess("echo '"+expectedOutput+"'", "", nil, false, 0, false, 0, func(process *ProcessInfo) {
-			t.Logf("Process: %+v", process.stderr)
+			close(done)
 		})
 		if err != nil {
 			t.Fatalf("Error starting echo process: %v", err)
 		}
 		t.Logf("Started echo process with PID: %s", echoPID)
 
-		// Wait for process to complete (shell wrapper needs more time)
-		time.Sleep(20 * time.Millisecond)
+		// Wait for process to complete
+		waitForProcessDone(t, done, 5*time.Second)
 
 		// Get and verify output
 		logs, err := pm.GetProcessOutput(echoPID)
@@ -106,16 +119,17 @@ func TestProcessManagerIntegrationWithPID(t *testing.T) {
 
 	// Test process with working directory
 	t.Run("ProcessWithWorkingDirectory", func(t *testing.T) {
+		done := make(chan struct{})
 		lsPID, err := pm.StartProcess("ls -la", "/tmp", nil, false, 0, false, 0, func(process *ProcessInfo) {
-			t.Logf("Process: %+v", process.stderr)
+			close(done)
 		})
 		if err != nil {
 			t.Fatalf("Error starting ls process: %v", err)
 		}
 		t.Logf("Started ls process with PID: %s in /tmp directory", lsPID)
 
-		// Wait for process to complete (shell wrapper needs more time)
-		time.Sleep(20 * time.Millisecond)
+		// Wait for process to complete
+		waitForProcessDone(t, done, 5*time.Second)
 
 		// Get and verify output
 		logs, err := pm.GetProcessOutput(lsPID)

--- a/sandbox-api/src/handler/process/state.go
+++ b/sandbox-api/src/handler/process/state.go
@@ -47,7 +47,7 @@ type ProcessState struct {
 	RestartOnFailure bool                    `json:"restartOnFailure"`
 	MaxRestarts      int                     `json:"maxRestarts"`
 	RestartCount     int                     `json:"restartCount"`
-	Env              map[string]string       `json:"env,omitempty"`
+	Env              []string                `json:"env,omitempty"` // Resolved environment (system + custom) for restart-on-failure
 }
 
 // ManagerState represents the full state of the process manager
@@ -112,6 +112,7 @@ func (pm *ProcessManager) SaveState() error {
 			RestartOnFailure: proc.RestartOnFailure,
 			MaxRestarts:      proc.MaxRestarts,
 			RestartCount:     proc.RestartCount,
+			Env:              proc.Env,
 		}
 
 		logrus.WithFields(logrus.Fields{
@@ -221,6 +222,7 @@ func (pm *ProcessManager) LoadState() error {
 			RestartOnFailure: procState.RestartOnFailure,
 			MaxRestarts:      procState.MaxRestarts,
 			RestartCount:     procState.RestartCount,
+			Env:              procState.Env,
 			Done:             make(chan struct{}),
 			stdout:           &strings.Builder{},
 			stderr:           &strings.Builder{},

--- a/sandbox-api/src/handler/process/state.go
+++ b/sandbox-api/src/handler/process/state.go
@@ -47,7 +47,7 @@ type ProcessState struct {
 	RestartOnFailure bool                    `json:"restartOnFailure"`
 	MaxRestarts      int                     `json:"maxRestarts"`
 	RestartCount     int                     `json:"restartCount"`
-	Env              []string                `json:"env,omitempty"` // Resolved environment (system + custom) for restart-on-failure
+	Env              map[string]string       `json:"env,omitempty"` // Custom env vars provided at start, reused on restart-on-failure
 }
 
 // ManagerState represents the full state of the process manager


### PR DESCRIPTION
## What

Two fixes to process restart-on-failure:

1. **Env was lost on restart.** When a process restarted after a failure, the child was started with `os.Environ()` (the sandbox-api's own environment), so any custom env vars passed at the first start were dropped. We now store the resolved environment on the process (and persist it in state) and reuse it on every restart.

2. **`maxRestarts = -1` now means unlimited.** Before, the `RestartCount < MaxRestarts` check made any negative value a no-restart. A negative `maxRestarts` (e.g. `-1`) now restarts forever. Restart log messages show `restart N/unlimited` in that case.

## Why

A process restarted by the restart policy was not getting back the environment it was first given. Customers relying on custom env vars (ports, secrets, config) would see them silently disappear after the first failure.

## Tests

Unit tests (`src/handler/process`):
- `RestartPreservesEnvironment` - custom var present on both the initial run and the restart, never empty.
- `UnlimitedRestartsWithNegativeMax` - fails 3 times then succeeds with `maxRestarts: -1`, log shows `restart N/unlimited`.

Integration tests (`integration-tests/tests/process`), run against a local live API:
- `TestProcessRestartPreservesEnvironment`
- `TestProcessUnlimitedRestarts`

Both pass. API reference regenerated (`make reference`) for the updated `maxRestarts` doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes two restart-on-failure bugs: custom env vars being silently dropped on restart (the restart path used `os.Environ()` instead of the original env), and `maxRestarts < 0` being treated as no-restart instead of unlimited. Stores the user-provided custom env vars on `ProcessInfo` with `json:"-"`, persists them in `ProcessState.Env` (`map[string]string`), and re-merges with `os.Environ()` via `buildProcessEnv` at each restart. Adds unit and integration tests for both fixes, and replaces racy `time.Sleep` in two existing tests with completion-channel waits.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit cc32f6178ab0d710977c983cbf18ab0e4ee6108c.</sup>
<!-- /MENDRAL_SUMMARY -->