### PR TITLE
feat(hub): add node-slim sandbox template

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,7 @@ on:
           - lightpanda
           - nextjs
           - node
+          - node-slim
           - playwright-chromium
           - playwright-firefox
           - py-app

--- a/hub/node-slim/Dockerfile
+++ b/hub/node-slim/Dockerfile
@@ -1,0 +1,20 @@
+ARG SANDBOX_VERSION=latest
+FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
+
+FROM node:23-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  bash \
+  git \
+  ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /blaxel
+
+COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
+
+EXPOSE 8080 3000
+
+ENV HOME=/blaxel
+
+ENTRYPOINT ["/usr/local/bin/sandbox-api"]

--- a/hub/node-slim/template.json
+++ b/hub/node-slim/template.json
@@ -1,0 +1,20 @@
+{
+  "name": "node-slim",
+  "displayName": "Node Slim",
+  "categories": ["backend"],
+  "description": "A development environment for Node.js applications built on Debian slim (glibc).",
+  "longDescription": "The Node Slim micro VM provides a complete Node.js development environment built on Debian slim (glibc) instead of Alpine (musl). This matters for heavy native npm modules such as duckdb, canvas, and sharp: on Alpine/musl they fall back to compiling from source because no musl prebuilt binaries are published, which is slow and frequently fails on constrained sandboxes. On Debian glibc these modules install official prebuilt binaries instead, so installs are fast and reliable. It ships Node.js 23, npm, git, and bash pre-installed.",
+  "url": "https://nodejs.org/en",
+  "icon": "https://avatars.githubusercontent.com/u/9950313?s=200&v=4",
+  "memory": 4096,
+  "ports": [
+    {
+      "name": "sandbox-api",
+      "target": 8080,
+      "protocol": "HTTP"
+    }
+  ],
+  "enterprise": false,
+  "coming_soon": false,
+  "hidden": true
+}


### PR DESCRIPTION
## What

Adds a new `node-slim` hub sandbox template: a Node.js 23 environment built on **Debian slim (glibc)** instead of Alpine (musl).

## Why

Heavy native npm modules (`duckdb`, `canvas`, `sharp`, ...) publish glibc prebuilt binaries but no musl ones. On Alpine they fall back to compiling from source, which is slow and frequently fails on constrained sandboxes. On Debian glibc they install the official prebuilts, so installs are fast and reliable.

## Changes

- `hub/node-slim/Dockerfile` — `node:23-slim` base, bundles the `sandbox-api` binary, ships git + bash.
- `hub/node-slim/template.json` — template metadata (4 GB memory, hidden for now).
- `.github/workflows/build.yaml` — register `node-slim` in the manual `workflow_dispatch` sandbox options. The automatic build matrix already picks it up via the `hub/` directory scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new `node-slim` sandbox template using `node:23-slim` (Debian glibc) instead of Alpine to support native npm modules like duckdb, canvas, and sharp that ship glibc prebuilts only. Includes the Dockerfile, template metadata, and CI workflow registration.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 244ad02e9f5e367a42f0ac807ffafdc0a97a270e.</sup>
<!-- /MENDRAL_SUMMARY -->