### PR TITLE
chore: bump all templates to Node 24 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Sandbox Hub is a collection of development environment templates for creating se
 The hub directory contains the following templates:
 
 ### Base Image
-A minimal micro VM environment based on **Alpine Linux** (`node:22-alpine`) with basic system utilities and networking capabilities. Provides a lightweight, secure foundation for running basic applications and services, featuring a minimal attack surface and optimized resource usage.
+A minimal micro VM environment based on **Alpine Linux** (`node:24-alpine`) with basic system utilities and networking capabilities. Provides a lightweight, secure foundation for running basic applications and services, featuring a minimal attack surface and optimized resource usage.
 
-> **Important:** The base image includes **Node.js 22** and **git**, but does **not** include Python or other language runtimes. If you need Python, either use the [`py-app`](#python-app) template or install it manually:
+> **Important:** The base image includes **Node.js 24** and **git**, but does **not** include Python or other language runtimes. If you need Python, either use the [`py-app`](#python-app) template or install it manually:
 > ```bash
 > apk add --no-cache python3 py3-pip
 > ```

--- a/e2e/codegen/Dockerfile
+++ b/e2e/codegen/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 
 RUN apk update && apk add --no-cache \
   git \

--- a/e2e/custom-sandbox-with-copy/Dockerfile
+++ b/e2e/custom-sandbox-with-copy/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23-slim
+FROM node:24-slim
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/e2e/custom-sandbox/Dockerfile
+++ b/e2e/custom-sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23-slim
+FROM node:24-slim
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/e2e/debian/Dockerfile
+++ b/e2e/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23-slim
+FROM node:24-slim
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/e2e/simple-custom-sandbox/Dockerfile
+++ b/e2e/simple-custom-sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:24-slim
 
 RUN apt-get update && apt-get install -y curl git ca-certificates && rm -rf /var/lib/apt/lists/*
 

--- a/hub/app-runner/Dockerfile
+++ b/hub/app-runner/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:22-alpine
+FROM node:24-alpine
 
 RUN apk update && apk add --no-cache \
   bash \

--- a/hub/astro/Dockerfile
+++ b/hub/astro/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:22-alpine
+FROM node:24-alpine
 
 RUN apk update && apk add --no-cache \
   bash \

--- a/hub/astro/template.json
+++ b/hub/astro/template.json
@@ -4,7 +4,7 @@
   "categories": ["web"],
   "description": "A complete development environment for Astro applications with a dev server ready at startup.",
   "icon": "https://astro.build/assets/press/astro-icon-light-gradient.svg",
-  "longDescription": "The Astro micro VM provides a comprehensive development environment for building Astro applications. It includes Node.js runtime, npm package manager, and all necessary tools for building content-driven websites. Features hot reloading, island architecture, and zero JavaScript by default. Perfect for developing fast, content-focused websites with Astro's modern web framework. Built on Alpine Linux with Node.js 22, and ships with git, curl, and npm pre-installed.",
+  "longDescription": "The Astro micro VM provides a comprehensive development environment for building Astro applications. It includes Node.js runtime, npm package manager, and all necessary tools for building content-driven websites. Features hot reloading, island architecture, and zero JavaScript by default. Perfect for developing fast, content-focused websites with Astro's modern web framework. Built on Alpine Linux with Node.js 24, and ships with git, curl, and npm pre-installed.",
   "url": "https://github.com/withastro/astro",
   "memory": 4096,
   "ports": [

--- a/hub/base-image/Dockerfile
+++ b/hub/base-image/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:22-alpine
+FROM node:24-alpine
 
 RUN apk update && apk add --no-cache \
   bash \

--- a/hub/base-image/template.json
+++ b/hub/base-image/template.json
@@ -3,7 +3,7 @@
   "displayName": "Base Image",
   "categories": [],
   "description": "A minimal micro VM environment with basic system utilities and networking capabilities",
-  "longDescription": "The Base Image micro VM provides a lightweight, secure environment with essential system utilities and networking capabilities. It's designed as a foundation for running basic applications and services, featuring a minimal attack surface and optimized resource usage. Built on Alpine Linux with Node.js 22, and ships with git and npm pre-installed.",
+  "longDescription": "The Base Image micro VM provides a lightweight, secure environment with essential system utilities and networking capabilities. It's designed as a foundation for running basic applications and services, featuring a minimal attack surface and optimized resource usage. Built on Alpine Linux with Node.js 24, and ships with git and npm pre-installed.",
   "url": "https://github.com/firecracker-microvm",
   "icon": "https://avatars.githubusercontent.com/u/44477506?s=200&v=4",
   "memory": 4096,

--- a/hub/expo/Dockerfile
+++ b/hub/expo/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:22-alpine
+FROM node:24-alpine
 
 RUN apk update && apk add --no-cache \
   bash \

--- a/hub/expo/template.json
+++ b/hub/expo/template.json
@@ -4,7 +4,7 @@
   "categories": ["mobile"],
   "description": "A complete development environment for React Native applications using Expo framework.",
   "icon": "https://avatars.githubusercontent.com/u/12504344?s=200&v=4",
-  "longDescription": "The Expo micro VM provides a comprehensive development environment for building React Native applications using the Expo framework. It includes the Expo CLI, development server, and all necessary tools for cross-platform mobile development. Features hot reloading, over-the-air updates, and access to native device features through Expo's managed workflow. Perfect for developing iOS and Android applications with a single codebase. Built on Alpine Linux with Node.js 22, and ships with git, curl, npm, and the Expo CLI pre-installed.",
+  "longDescription": "The Expo micro VM provides a comprehensive development environment for building React Native applications using the Expo framework. It includes the Expo CLI, development server, and all necessary tools for cross-platform mobile development. Features hot reloading, over-the-air updates, and access to native device features through Expo's managed workflow. Perfect for developing iOS and Android applications with a single codebase. Built on Alpine Linux with Node.js 24, and ships with git, curl, npm, and the Expo CLI pre-installed.",
   "url": "https://github.com/expo",
   "memory": 4096,
   "ports": [

--- a/hub/nextjs/Dockerfile
+++ b/hub/nextjs/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:22-alpine
+FROM node:24-alpine
 
 RUN apk update && apk add --no-cache \
   bash \

--- a/hub/nextjs/template.json
+++ b/hub/nextjs/template.json
@@ -4,7 +4,7 @@
   "categories": ["web"],
   "description": "A complete development environment for React applications using Next.js framework.",
   "icon": "https://assets.vercel.com/image/upload/v1662130559/nextjs/Icon_dark_background.png",
-  "longDescription": "Next.js is a React framework for building server-side rendered (SSR), static site generation (SSG), and hybrid client-side rendered (CSR) web applications using React. It includes a routing system, a build optimizer, and a development server. Built on Alpine Linux with Node.js 22, and ships with git, curl, and npm pre-installed.",
+  "longDescription": "Next.js is a React framework for building server-side rendered (SSR), static site generation (SSG), and hybrid client-side rendered (CSR) web applications using React. It includes a routing system, a build optimizer, and a development server. Built on Alpine Linux with Node.js 24, and ships with git, curl, and npm pre-installed.",
   "url": "https://github.com/vercel/next.js",
   "memory": 4096,
   "ports": [

--- a/hub/node-slim/Dockerfile
+++ b/hub/node-slim/Dockerfile
@@ -1,7 +1,13 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:23-slim
+# Node 24 (current LTS), on Debian slim (glibc). Two reasons over node:23-alpine:
+# (1) glibc — heavy native modules (duckdb, canvas, ...) ship glibc node-pre-gyp
+#     prebuilts but no musl ones, so on Alpine they compile from source and fail.
+# (2) Node 24 (ABI node-v137) — duckdb publishes a v137 prebuilt; Node 23
+#     (v131, a non-LTS odd release) was skipped, so it 404s and falls back to a
+#     source compile. Node 24 downloads the prebuilt and just works.
+FROM node:24-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   bash \

--- a/hub/node-slim/template.json
+++ b/hub/node-slim/template.json
@@ -3,7 +3,7 @@
   "displayName": "Node Slim",
   "categories": ["backend"],
   "description": "A development environment for Node.js applications built on Debian slim (glibc).",
-  "longDescription": "The Node Slim micro VM provides a complete Node.js development environment built on Debian slim (glibc) instead of Alpine (musl). This matters for heavy native npm modules such as duckdb, canvas, and sharp: on Alpine/musl they fall back to compiling from source because no musl prebuilt binaries are published, which is slow and frequently fails on constrained sandboxes. On Debian glibc these modules install official prebuilt binaries instead, so installs are fast and reliable. It ships Node.js 23, npm, git, and bash pre-installed.",
+  "longDescription": "The Node Slim micro VM provides a complete Node.js development environment built on Debian slim (glibc) instead of Alpine (musl). This matters for heavy native npm modules such as duckdb, canvas, and sharp: on Alpine/musl they fall back to compiling from source because no musl prebuilt binaries are published, which is slow and frequently fails on constrained sandboxes. On Debian glibc these modules install official prebuilt binaries instead, so installs are fast and reliable. It ships Node.js 24, npm, git, and bash pre-installed.",
   "url": "https://nodejs.org/en",
   "icon": "https://avatars.githubusercontent.com/u/9950313?s=200&v=4",
   "memory": 4096,

--- a/hub/node/Dockerfile
+++ b/hub/node/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:23-alpine
+FROM node:24-alpine
 
 RUN apk update && apk add --no-cache \
   bash \

--- a/hub/node/template.json
+++ b/hub/node/template.json
@@ -3,7 +3,7 @@
   "displayName": "Node",
   "categories": ["backend"],
   "description": "A development environment for Node.js applications with essential development tools.",
-  "longDescription": "The Node micro VM provides a complete development environment for building Node.js applications. It includes Node.js runtime, npm package manager, and essential development tools. Perfect for developing modern web applications, APIs, and server-side applications with type safety and modern JavaScript features. Built on Alpine Linux with Node.js 23, and ships with git and npm pre-installed.",
+  "longDescription": "The Node micro VM provides a complete development environment for building Node.js applications. It includes Node.js runtime, npm package manager, and essential development tools. Perfect for developing modern web applications, APIs, and server-side applications with type safety and modern JavaScript features. Built on Alpine Linux with Node.js 24, and ships with git and npm pre-installed.",
   "url": "https://nodejs.org/en",
   "icon": "https://avatars.githubusercontent.com/u/9950313?s=200&v=4",
   "memory": 4096,

--- a/hub/playwright-chromium/Dockerfile
+++ b/hub/playwright-chromium/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:20-bookworm
+FROM node:24-bookworm
 
 WORKDIR /home/playwright
 

--- a/hub/playwright-chromium/template.json
+++ b/hub/playwright-chromium/template.json
@@ -3,7 +3,7 @@
   "displayName": "Playwright Chromium",
   "categories": ["browser", "testing"],
   "description": "A Playwright server environment with Chromium browser for automated browser testing and web scraping.",
-  "longDescription": "The Playwright Chromium sandbox provides a complete Playwright server environment with the Chromium browser pre-installed. It enables automated browser testing, web scraping, and browser automation through Playwright's WebSocket-based protocol. Ideal for running end-to-end tests, generating screenshots, and automating web interactions with Chromium. Built on Debian Bookworm with Node.js 20, and ships with Playwright 1.58, Chromium, build-essential, net-tools, and npm pre-installed.",
+  "longDescription": "The Playwright Chromium sandbox provides a complete Playwright server environment with the Chromium browser pre-installed. It enables automated browser testing, web scraping, and browser automation through Playwright's WebSocket-based protocol. Ideal for running end-to-end tests, generating screenshots, and automating web interactions with Chromium. Built on Debian Bookworm with Node.js 24, and ships with Playwright 1.58, Chromium, build-essential, net-tools, and npm pre-installed.",
   "url": "https://playwright.dev",
   "icon": "https://playwright.dev/img/playwright-logo.svg",
   "memory": 4096,

--- a/hub/playwright-firefox/Dockerfile
+++ b/hub/playwright-firefox/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:20-bookworm
+FROM node:24-bookworm
 
 WORKDIR /home/playwright
 

--- a/hub/playwright-firefox/template.json
+++ b/hub/playwright-firefox/template.json
@@ -3,7 +3,7 @@
   "displayName": "Playwright Firefox",
   "categories": ["browser", "testing"],
   "description": "A Playwright server environment with Firefox browser for automated browser testing and web scraping.",
-  "longDescription": "The Playwright Firefox sandbox provides a complete Playwright server environment with the Firefox browser pre-installed. It enables automated browser testing, web scraping, and browser automation through Playwright's WebSocket-based protocol. Ideal for running end-to-end tests, generating screenshots, and automating web interactions with Firefox. Built on Debian Bookworm with Node.js 20, and ships with Playwright 1.58, Firefox, build-essential, net-tools, and npm pre-installed.",
+  "longDescription": "The Playwright Firefox sandbox provides a complete Playwright server environment with the Firefox browser pre-installed. It enables automated browser testing, web scraping, and browser automation through Playwright's WebSocket-based protocol. Ideal for running end-to-end tests, generating screenshots, and automating web interactions with Firefox. Built on Debian Bookworm with Node.js 24, and ships with Playwright 1.58, Firefox, build-essential, net-tools, and npm pre-installed.",
   "url": "https://playwright.dev",
   "icon": "https://playwright.dev/img/playwright-logo.svg",
   "memory": 4096,

--- a/hub/ts-app/Dockerfile
+++ b/hub/ts-app/Dockerfile
@@ -2,7 +2,7 @@ ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
 # Use an official Python runtime as a parent image
-FROM node:22-slim
+FROM node:24-slim
 
 RUN apt-get update && apt-get install -y git \
   && rm -rf /var/lib/apt/lists/*

--- a/hub/ts-app/template.json
+++ b/hub/ts-app/template.json
@@ -3,7 +3,7 @@
   "displayName": "Typescript App",
   "categories": ["backend"],
   "description": "A development environment for TypeScript applications with Node.js runtime and essential development tools.",
-  "longDescription": "The TypeScript App micro VM provides a complete development environment for building TypeScript applications. It includes Node.js runtime, npm package manager, and essential development tools. Perfect for developing modern web applications, APIs, and server-side applications with type safety and modern JavaScript features. Built on Debian (slim) with Node.js 22, and ships with git and npm pre-installed.",
+  "longDescription": "The TypeScript App micro VM provides a complete development environment for building TypeScript applications. It includes Node.js runtime, npm package manager, and essential development tools. Perfect for developing modern web applications, APIs, and server-side applications with type safety and modern JavaScript features. Built on Debian (slim) with Node.js 24, and ships with git and npm pre-installed.",
   "url": "https://github.com/microsoft/typescript",
   "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/Typescript.svg/250px-Typescript.svg.png",
   "memory": 2048,

--- a/hub/vite/Dockerfile
+++ b/hub/vite/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:22-alpine
+FROM node:24-alpine
 
 RUN apk update && apk add --no-cache \
   bash \

--- a/hub/vite/template.json
+++ b/hub/vite/template.json
@@ -5,7 +5,7 @@
     "web"
   ],
   "description": "A simple Vite app",
-  "longDescription": "The Vite app is a simple Vite app with React and TypeScript. It's ideal for building a simple web app. Built on Alpine Linux with Node.js 22, and ships with git, curl, and npm pre-installed.",
+  "longDescription": "The Vite app is a simple Vite app with React and TypeScript. It's ideal for building a simple web app. Built on Alpine Linux with Node.js 24, and ships with git, curl, and npm pre-installed.",
   "url": "https://vitejs.dev",
   "icon": "https://vitejs.dev/logo.svg",
   "memory": 4096,


### PR DESCRIPTION
## What

Bumps every hub and e2e template to **Node 24** (the current LTS).

Each image keeps its existing variant:
- `alpine` templates → `node:24-alpine`
- `slim` templates → `node:24-slim`
- `bookworm` (playwright) templates → `node:24-bookworm`

This replaces the previous mix of Node 20 / 22 / 23, including a couple of non-LTS odd releases.

## Files

- All `Dockerfile`s under `hub/` and `e2e/`
- Matching `template.json` long descriptions
- README template section

## Notes

- `node-slim` was already on `node:24-slim` (this branch builds on it).
- The `node:23-alpine` mention left in `hub/node-slim/Dockerfile` is intentional: it's the rationale comment explaining why slim/glibc + Node 24 is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Standardizes all hub and e2e Dockerfiles on Node 24 LTS, replacing the prior mix of Node 20/22/23 (including non-LTS odd releases). Each image keeps its existing variant (alpine/slim/bookworm). Matching template.json long descriptions and README are updated to reflect the new version.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3801c75f4eafc00150c56753623da448746b48dd.</sup>
<!-- /MENDRAL_SUMMARY -->