### PR TITLE
fix(hub): bump playwright to 1.60.0 to fix node 24 build hang

### DIFF
--- a/hub/playwright-chromium/Dockerfile
+++ b/hub/playwright-chromium/Dockerfile
@@ -12,13 +12,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential net-tools \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Playwright globally (for CLI) and locally (for require())
+# Install Playwright globally (for CLI) and locally (for require()).
+# Pinned to 1.60.0: on node:24-bookworm, playwright <= 1.59.x hangs forever
+# while extracting the downloaded browser archive (the download itself
+# succeeds). 1.60.0 fixes the extraction, so the image builds again.
 RUN npm cache clean --force && \
-    npm i -g playwright@1.58.2 playwright-core@1.58.2 && \
+    npm i -g playwright@1.60.0 playwright-core@1.60.0 && \
     npm i -g happy-eyeballs && \
     playwright install --with-deps chromium
 
-RUN npm init -y && npm i playwright-core@1.58.2
+RUN npm init -y && npm i playwright-core@1.60.0
 
 COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
 

--- a/hub/playwright-firefox/Dockerfile
+++ b/hub/playwright-firefox/Dockerfile
@@ -12,13 +12,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential net-tools \
     && rm -rf /var/lib/apt/lists/*
 
-# Clean npm cache and install Playwright with explicit dependencies
+# Clean npm cache and install Playwright with explicit dependencies.
+# Pinned to 1.60.0: on node:24-bookworm, playwright <= 1.59.x hangs forever
+# while extracting the downloaded browser archive (the download itself
+# succeeds). 1.60.0 fixes the extraction, so the image builds again.
 RUN npm cache clean --force && \
-    npm i -g playwright@1.58.2 playwright-core@1.58.2 && \
+    npm i -g playwright@1.60.0 playwright-core@1.60.0 && \
     npm i -g happy-eyeballs && \
     playwright install --with-deps firefox
 
-RUN npm init -y && npm i playwright-core@1.58.2
+RUN npm init -y && npm i playwright-core@1.60.0
 
 COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
 


### PR DESCRIPTION
## Problem

The Node 24 LTS bump (#216) moved `playwright-chromium` and `playwright-firefox` to `node:24-bookworm`. On Node 24, **playwright ≤ 1.59.x hangs forever while extracting the downloaded browser archive**.

Reproduced locally on `node:24-bookworm` with `DEBUG=pw:install`:

```
pw:install -- download complete, size: 188304613
pw:install SUCCESS downloading Chrome for Testing ...
pw:install removing existing browser directory if any
   <hangs forever — extraction never returns>
```

The download succeeds; the **extraction** never returns. This stalled the `v0.2.31` release for 90+ minutes (both playwright ghcr builds hung, so the publish step never ran). The same build took ~2 min on the previous `node:20-bookworm` release.

## Root cause

Node 24 breaks playwright's browser-archive extraction. It is not apt, network, or architecture related (reproduced on both GitHub amd64 and local arm64; apt + download both succeed).

| Base image | Extraction |
|---|---|
| `node:20-bookworm` (before) | ✅ |
| `node:24-bookworm` + pw 1.58.2 / 1.59.x | ❌ hangs |
| `node:24-bookworm` + pw **1.60.0** | ✅ |

## Fix

Bump pinned playwright from `1.58.2` to `1.60.0` (latest) in both Dockerfiles. Node stays on 24.

## Validation (local, node:24-bookworm)

- **chromium** and **firefox**: install + extraction complete (no hang)
- runtime: `playwright run-server` + `firefox.connect()` → load `example.com` → `TITLE: Example Domain` ✅

Browser versions move with the bump (chromium → Chrome 148). Full hub re-verification will run after the next release publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Bumps pinned Playwright from 1.58.2 to 1.60.0 in both playwright-chromium and playwright-firefox Dockerfiles to fix a Node 24 build hang where browser archive extraction never completes. Adds inline comments explaining the pin rationale.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b207faca8b966b73791af60b74abe6c6a2f27be1.</sup>
<!-- /MENDRAL_SUMMARY -->