### PR TITLE
fix(sandbox-api): default /upgrade to "latest" instead of "develop"

### DIFF
--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -1707,7 +1707,7 @@ const docTemplate = `{
         },
         "/upgrade": {
             "post": {
-                "description": "Triggers an upgrade of the sandbox-api process. Returns 200 immediately before upgrading.\nThe upgrade will: download the specified binary from GitHub releases, validate it, and restart.\nAll running processes will be preserved across the upgrade.\nAvailable versions: \"develop\" (default), \"main\", \"latest\", or specific tag like \"v1.0.0\"\nYou can also specify a custom baseUrl for forks (defaults to https://github.com/blaxel-ai/sandbox/releases)",
+                "description": "Triggers an upgrade of the sandbox-api process. Returns 200 immediately before upgrading.\nThe upgrade will: download the specified binary from GitHub releases, validate it, and restart.\nAll running processes will be preserved across the upgrade.\nAvailable versions: \"latest\" (default, most recent release), \"develop\", \"main\", or specific tag like \"v1.0.0\"\nYou can also specify a custom baseUrl for forks (defaults to https://github.com/blaxel-ai/sandbox/releases)",
                 "consumes": [
                     "application/json"
                 ],
@@ -2653,9 +2653,9 @@ const docTemplate = `{
                     "example": "https://github.com/blaxel-ai/sandbox/releases"
                 },
                 "version": {
-                    "description": "Version to upgrade to: \"develop\", \"main\", \"latest\", or specific tag like \"v1.0.0\"",
+                    "description": "Version to upgrade to: \"latest\" (default), \"develop\", \"main\", or specific tag like \"v1.0.0\"",
                     "type": "string",
-                    "example": "develop"
+                    "example": "latest"
                 }
             }
         },

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -1402,7 +1402,7 @@ paths:
 
         All running processes will be preserved across the upgrade.
 
-        Available versions: "develop" (default), "main", "latest", or specific tag like "v1.0.0"
+        Available versions: "latest" (default, most recent release), "develop", "main", or specific tag like "v1.0.0"
 
         You can also specify a custom baseUrl for forks (defaults to https://github.com/blaxel-ai/sandbox/releases)
       requestBody:
@@ -2106,8 +2106,8 @@ components:
           example: https://github.com/blaxel-ai/sandbox/releases
           type: string
         version:
-          description: 'Version to upgrade to: "develop", "main", "latest", or specific tag like "v1.0.0"'
-          example: develop
+          description: 'Version to upgrade to: "latest" (default), "develop", "main", or specific tag like "v1.0.0"'
+          example: latest
           type: string
       type: object
     UpgradeStatus:

--- a/sandbox-api/src/handler/system.go
+++ b/sandbox-api/src/handler/system.go
@@ -93,16 +93,32 @@ func (h *SystemHandler) HandleHealth(c *gin.Context) {
 
 // UpgradeRequest represents the request body for the upgrade endpoint
 type UpgradeRequest struct {
-	Version string `json:"version" example:"develop"`                                        // Version to upgrade to: "develop", "main", "latest", or specific tag like "v1.0.0"
+	Version string `json:"version" example:"latest"`                                         // Version to upgrade to: "latest" (default), "develop", "main", or specific tag like "v1.0.0"
 	BaseURL string `json:"baseUrl" example:"https://github.com/blaxel-ai/sandbox/releases"` // Base URL for releases (useful for forks)
 } // @name UpgradeRequest
+
+// defaultUpgradeVersion is the version used when an upgrade request omits one.
+// "latest" resolves to the most recent published release, the safe production
+// default. It replaces the former "develop" default, which tracked the dev
+// branch HEAD and could be older than the running binary, silently downgrading
+// the sandbox (ENG-2974).
+const defaultUpgradeVersion = "latest"
+
+// resolveUpgradeVersion returns the requested version, falling back to the
+// default when none is provided.
+func resolveUpgradeVersion(requested string) string {
+	if requested == "" {
+		return defaultUpgradeVersion
+	}
+	return requested
+}
 
 // HandleUpgrade handles POST requests to /upgrade
 // @Summary Upgrade the sandbox-api
 // @Description Triggers an upgrade of the sandbox-api process. Returns 200 immediately before upgrading.
 // @Description The upgrade will: download the specified binary from GitHub releases, validate it, and restart.
 // @Description All running processes will be preserved across the upgrade.
-// @Description Available versions: "develop" (default), "main", "latest", or specific tag like "v1.0.0"
+// @Description Available versions: "latest" (default, most recent release), "develop", "main", or specific tag like "v1.0.0"
 // @Description You can also specify a custom baseUrl for forks (defaults to https://github.com/blaxel-ai/sandbox/releases)
 // @Tags system
 // @Accept json
@@ -116,11 +132,8 @@ func (h *SystemHandler) HandleUpgrade(c *gin.Context) {
 	var req UpgradeRequest
 	c.ShouldBindJSON(&req) // Ignore errors - empty body is valid
 
-	// Default to "develop" if no version specified
-	version := req.Version
-	if version == "" {
-		version = "develop"
-	}
+	// Default to "latest" if no version specified (see resolveUpgradeVersion).
+	version := resolveUpgradeVersion(req.Version)
 
 	// Default base URL
 	baseURL := req.BaseURL

--- a/sandbox-api/src/handler/system_test.go
+++ b/sandbox-api/src/handler/system_test.go
@@ -1,0 +1,29 @@
+package handler
+
+import "testing"
+
+// TestResolveUpgradeVersion verifies the default upgrade version logic.
+// Regression test for ENG-2974: an empty version must resolve to "latest"
+// (the most recent published release) rather than "develop", which could
+// silently downgrade the running binary.
+func TestResolveUpgradeVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		want      string
+	}{
+		{name: "empty defaults to latest", requested: "", want: "latest"},
+		{name: "explicit develop is preserved", requested: "develop", want: "develop"},
+		{name: "explicit main is preserved", requested: "main", want: "main"},
+		{name: "explicit tag is preserved", requested: "v1.0.0", want: "v1.0.0"},
+		{name: "explicit latest is preserved", requested: "latest", want: "latest"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveUpgradeVersion(tt.requested); got != tt.want {
+				t.Errorf("resolveUpgradeVersion(%q) = %q, want %q", tt.requested, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`POST /upgrade` without an explicit `version` defaulted to `develop`. Since `develop` tracks the dev branch HEAD, it can be older than the binary already running, so the "upgrade" silently downgrades the sandbox (observed: v0.2.26 from 2026-04-20 "upgraded" to a develop build from 2026-04-16).

This changes the default to `latest`, the most recent published release and the safe production default.

## Changes

- Default upgrade version `develop` → `latest`.
- Extract the logic into a reusable, testable `resolveUpgradeVersion` helper + `defaultUpgradeVersion` constant.
- Update Swagger annotations and regenerate `docs.go` / `openapi.yml`.
- Add `TestResolveUpgradeVersion` regression test.

## Testing

- `go build ./...`, `go vet ./src/handler/` pass.
- New unit test (5 cases) + full `src/handler` suite pass.

Closes ENG-2974

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Changes the default upgrade version from "develop" to "latest" to prevent silent downgrades when `POST /upgrade` is called without an explicit version. Extracts the resolution logic into a testable helper function and adds a regression test.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit bb462e0e2f80b82ba924389e37cb299f504b6554.</sup>
<!-- /MENDRAL_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->