### PR TITLE
Add Claude Code and Codex sandbox images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,8 @@ on:
           - app-runner
           - astro
           - base-image
+          - claude-code
+          - codex
           - chromium
           - cua-xfce
           - docker-in-sandbox

--- a/hub/claude-code/Dockerfile
+++ b/hub/claude-code/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:24-slim
+FROM node:24-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   bash \

--- a/hub/claude-code/Dockerfile
+++ b/hub/claude-code/Dockerfile
@@ -1,0 +1,25 @@
+ARG SANDBOX_VERSION=latest
+FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
+
+FROM node:24-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  bash \
+  ca-certificates \
+  curl \
+  git \
+  ripgrep \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code@latest
+
+WORKDIR /blaxel
+
+COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
+RUN chmod +x /usr/local/bin/sandbox-api
+
+EXPOSE 8080
+
+ENV HOME=/blaxel
+
+ENTRYPOINT ["/usr/local/bin/sandbox-api"]

--- a/hub/claude-code/Dockerfile
+++ b/hub/claude-code/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ripgrep \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code@latest
+RUN npm install -g @anthropic-ai/claude-code@2.1.178
 
 WORKDIR /blaxel
 

--- a/hub/claude-code/template.json
+++ b/hub/claude-code/template.json
@@ -1,0 +1,20 @@
+{
+  "name": "claude-code",
+  "displayName": "Claude Code",
+  "categories": [],
+  "description": "A sandbox image with Claude Code pre-installed for agentic coding workflows.",
+  "longDescription": "The Claude Code sandbox image provides a Blaxel sandbox runtime with Claude Code installed and available on PATH as `claude`. Use it to create SDK-managed sandboxes where Claude Code can inspect files, run commands, and connect to other sandbox MCP servers without installing the CLI at runtime.",
+  "url": "https://docs.anthropic.com/en/docs/claude-code/overview",
+  "icon": "https://blaxel.ai/logo.png",
+  "memory": 8192,
+  "ports": [
+    {
+      "name": "sandbox-api",
+      "target": 8080,
+      "protocol": "HTTP"
+    }
+  ],
+  "enterprise": false,
+  "coming_soon": false,
+  "hidden": true
+}

--- a/hub/codex/Dockerfile
+++ b/hub/codex/Dockerfile
@@ -1,7 +1,7 @@
 ARG SANDBOX_VERSION=latest
 FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
-FROM node:24-slim
+FROM node:24-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   bash \

--- a/hub/codex/Dockerfile
+++ b/hub/codex/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ripgrep \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @openai/codex@latest
+RUN npm install -g @openai/codex@0.140.0
 
 WORKDIR /blaxel
 

--- a/hub/codex/Dockerfile
+++ b/hub/codex/Dockerfile
@@ -1,0 +1,25 @@
+ARG SANDBOX_VERSION=latest
+FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
+
+FROM node:24-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  bash \
+  ca-certificates \
+  curl \
+  git \
+  ripgrep \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @openai/codex@latest
+
+WORKDIR /blaxel
+
+COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
+RUN chmod +x /usr/local/bin/sandbox-api
+
+EXPOSE 8080
+
+ENV HOME=/blaxel
+
+ENTRYPOINT ["/usr/local/bin/sandbox-api"]

--- a/hub/codex/template.json
+++ b/hub/codex/template.json
@@ -1,0 +1,20 @@
+{
+  "name": "codex",
+  "displayName": "Codex",
+  "categories": [],
+  "description": "A sandbox image with Codex pre-installed for agentic coding workflows.",
+  "longDescription": "The Codex sandbox image provides a Blaxel sandbox runtime with OpenAI Codex installed and available on PATH as `codex`. Use it to create SDK-managed sandboxes where Codex can inspect files, run commands, and connect to other sandbox MCP servers without installing the CLI at runtime.",
+  "url": "https://github.com/openai/codex",
+  "icon": "https://blaxel.ai/logo.png",
+  "memory": 8192,
+  "ports": [
+    {
+      "name": "sandbox-api",
+      "target": 8080,
+      "protocol": "HTTP"
+    }
+  ],
+  "enterprise": false,
+  "coming_soon": false,
+  "hidden": true
+}


### PR DESCRIPTION
Fixes ENG-3178

What this is: hidden Sandbox Hub images for Claude Code and Codex so SDK-created sandboxes can use them directly.

What it changes:
- Adds `claude-code` and `codex` hub images with the sandbox API and the agent CLIs preinstalled.
- Adds both images to the manual hub build workflow options.

Checked locally: linux/amd64 builds and CLI smoke checks passed.

Linear: PM-2228

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds two new hidden sandbox hub images (Claude Code and Codex) with pinned CLI package versions and a digest-pinned `node:24-slim` base image, plus workflow entries for manual builds.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit afdbef7363420a95199545d08b4a6e5b8b9fbbab.</sup>
<!-- /MENDRAL_SUMMARY -->