### PR TITLE
fix: sandbox stats panel showed hostname as (none) on real Blaxel infra

### DIFF
--- a/hub/onboarder-nextjs/app-template/app/api/sandbox-info/route.ts
+++ b/hub/onboarder-nextjs/app-template/app/api/sandbox-info/route.ts
@@ -34,11 +34,23 @@ export async function GET() {
   // panel never shows a number that undercuts its own "this is real" point.
   const rssBytes = memory.rss || memory.heapUsed + memory.external;
 
+  // Real Blaxel sandboxes set BL_NAME (the sandbox's actual name) but do not
+  // give the container a meaningful kernel hostname — `hostname`/os.hostname()
+  // genuinely returns the literal string "(none)" there. Prefer BL_NAME (and
+  // its BLAXEL_* alias) so the panel shows a real identifier instead of that
+  // placeholder; only fall back to os.hostname() outside Blaxel (e.g. local
+  // dev/Docker), and never surface the literal "(none)" placeholder itself.
+  const osHostname = os.hostname();
+  const sandboxName =
+    firstEnv('BL_NAME', 'BLAXEL_NAME', 'BL_SANDBOX_NAME', 'BLAXEL_SANDBOX_NAME') ||
+    (osHostname !== '(none)' ? osHostname : '');
+  const hostname = sandboxName || (osHostname !== '(none)' ? osHostname : 'unavailable');
+
   return NextResponse.json({
     bootTimestamp,
     cwd: process.cwd(),
     freeMemoryMb: bytesToMb(os.freemem()),
-    hostname: os.hostname(),
+    hostname,
     loadAverage: os.loadavg().map((value) => Math.round(value * 100) / 100),
     node: process.version,
     pid: process.pid,
@@ -47,7 +59,7 @@ export async function GET() {
     region: firstEnv('BL_REGION', 'BLAXEL_REGION', 'REGION') || 'detected at runtime',
     requestCount,
     rssMemoryMb: bytesToMb(rssBytes),
-    sandboxName: firstEnv('BL_SANDBOX_NAME', 'BLAXEL_SANDBOX_NAME', 'HOSTNAME') || os.hostname(),
+    sandboxName: sandboxName || 'current sandbox',
     timestamp: new Date().toISOString(),
     totalMemoryMb: bytesToMb(os.totalmem()),
     uptimeSeconds: Math.round(process.uptime()),


### PR DESCRIPTION
Fixes ENG-3767

Caught this by actually testing on a live Blaxel dev sandbox, not just locally: the stats panel's hostname/sandboxName fields showed the literal string "(none)", because Blaxel containers don't set a kernel hostname and I'd guessed the wrong env var names. The real one Blaxel sets is `BL_NAME` (confirmed via env dump on a running dev sandbox).

Fixed to prefer `BL_NAME`/`BLAXEL_NAME`, never show the literal "(none)" placeholder, and only fall back to `os.hostname()` for local/Docker dev where it's meaningful.

Verified: hot-patched the fix directly onto the still-running dev sandbox via the filesystem API and confirmed `/api/sandbox-info` immediately returned the real sandbox name. This PR ships the same fix through the normal pipeline.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes the sandbox stats panel showing "(none)" as hostname/sandboxName on real Blaxel infrastructure by preferring the `BL_NAME`/`BLAXEL_NAME` env vars and filtering out the literal "(none)" string from `os.hostname()`.
>
> <sup>Written by [Mendral](https://mendral.com) for commit 83a340c737e1dd6200342ac3ef183d910a25faa1.</sup>
<!-- /MENDRAL_SUMMARY -->