### PR TITLE
fix(sandbox): make waitForPorts mean 'serving on a routable interface'

### DIFF
--- a/sandbox-api/src/handler/network/network.go
+++ b/sandbox-api/src/handler/network/network.go
@@ -183,21 +183,49 @@ func (n *Network) updatePortsForPID(pid int) error {
 	return nil
 }
 
-// getOpenPortsForPID uses platform-specific commands to get open ports for a specific PID
+// getOpenPortsForPID uses platform-specific commands to get open ports for a specific PID.
+//
+// Ports are attributed across the started process's whole subtree, not just its
+// own PID. A wrapped command such as `sh -c "sleep 2 && node ..."` registers the
+// shell's PID, but the listening socket is owned by the child (node/python)
+// under a different PID; a PID-scoped ss/netstat scan of only the parent never
+// sees it, which is why the PID-based readiness callback silently never fired
+// and waitForPorts fell back entirely to the connect poller. Walking children
+// here matches what getPortsUsingLsof already does on macOS.
 func getOpenPortsForPID(pid int) ([]*PortInfo, error) {
 	// Use different commands based on the operating system
 	if runtime.GOOS == "darwin" {
 		return getPortsUsingLsof(pid)
 	}
 
-	// For Linux systems, try ss command first (newer and more efficient)
-	portsInfo, err := getPortsUsingSS(pid)
-	if err == nil {
-		return portsInfo, nil
+	pidsToCheck := append([]int{pid}, getChildPIDs(pid)...)
+
+	var allPorts []*PortInfo
+	var firstErr error
+	gotResult := false
+	for _, checkPID := range pidsToCheck {
+		// For Linux systems, try ss command first (newer and more efficient)
+		portsInfo, err := getPortsUsingSS(checkPID)
+		if err != nil {
+			// Fall back to netstat if ss fails
+			portsInfo, err = getPortsUsingNetstat(checkPID)
+		}
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		gotResult = true
+		allPorts = append(allPorts, portsInfo...)
 	}
 
-	// Fall back to netstat if ss fails
-	return getPortsUsingNetstat(pid)
+	// Only surface an error when every attempt failed; a subtree PID that has
+	// already exited (e.g. the `sleep` in `sh -c "sleep 2 && ..."`) is expected.
+	if !gotResult && firstErr != nil {
+		return nil, firstErr
+	}
+	return allPorts, nil
 }
 
 // IsPortOpen checks if a specific port is open and listening.
@@ -251,6 +279,83 @@ func isPortOpenByConnect(port int) bool {
 	return true
 }
 
+// splitHostPort splits an "address:port" token as emitted by ss/netstat,
+// tolerating IPv6 forms ("[::]:3000", ":::3000") and the "*" wildcard the tools
+// use for an unspecified address/port. It returns the host (surrounding
+// brackets stripped, "*" preserved) and the numeric port.
+func splitHostPort(s string) (host string, port int, ok bool) {
+	idx := strings.LastIndex(s, ":")
+	if idx < 0 || idx == len(s)-1 {
+		return "", 0, false
+	}
+	host = s[:idx]
+	p, err := strconv.Atoi(s[idx+1:])
+	if err != nil {
+		// Peer entries often use "*" for the port (e.g. "0.0.0.0:*").
+		return "", 0, false
+	}
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	return host, p, true
+}
+
+// isLoopbackAddr reports whether addr is an IPv4/IPv6 loopback address. The
+// wildcard forms ("*", "0.0.0.0", "::") and concrete routable IPs are not
+// loopback.
+func isLoopbackAddr(addr string) bool {
+	if ip := net.ParseIP(addr); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// IsRoutableListener reports whether p is a listening socket bound to an
+// interface reachable from outside the microVM (i.e. not exclusively loopback).
+//
+// This is the crux of the readiness contract: the edge gateway proxies
+// /port/{n} straight to the microVM's routable IP, so a workload that is only
+// bound to 127.0.0.1 is "port-open" on a local connect yet still unreachable
+// through the gateway. Gating readiness on a routable LISTEN socket closes the
+// window where waitForPorts reported ready before the request path could serve.
+func IsRoutableListener(p *PortInfo) bool {
+	if p == nil {
+		return false
+	}
+	// Accept server sockets only: TCP "LISTEN" (ss/netstat/lsof) or UDP bound
+	// "UNCONN" (ss). An empty state is treated as a server socket so we never
+	// regress when the tool omits it. Connected states (ESTAB, TIME_WAIT, ...)
+	// belong to outbound/accepted connections and must not count as ready.
+	switch strings.ToUpper(p.State) {
+	case "", "LISTEN", "UNCONN":
+		return !isLoopbackAddr(p.LocalAddr)
+	default:
+		return false
+	}
+}
+
+// IsPortReady reports whether the given port is served by the process subtree of
+// pid on a routable interface — a stronger signal than IsPortOpen's bare
+// loopback connect. It falls back to the connect probe only when socket
+// enumeration is entirely unavailable, so it never regresses below the previous
+// behavior.
+func IsPortReady(pid, port int) bool {
+	ports, err := getOpenPortsForPID(pid)
+	if err != nil {
+		// Enumeration failed (ss/netstat/lsof unavailable) — degrade to the
+		// historical connect probe so readiness can still make progress.
+		return isPortOpenByConnect(port)
+	}
+	for _, p := range ports {
+		if p.LocalPort == port && IsRoutableListener(p) {
+			return true
+		}
+	}
+	// Enumeration worked but the port is not (yet) a routable listener. Do NOT
+	// fall back to a loopback connect here: a loopback-only bind must not count
+	// as ready, since the gateway could not reach it.
+	return false
+}
+
 // getPortsUsingSS uses the 'ss' command to get port information for a specific PID
 func getPortsUsingSS(pid int) ([]*PortInfo, error) {
 	// Run ss command: ss -tunap | grep <pid>
@@ -284,27 +389,17 @@ func getPortsUsingSS(pid int) ([]*PortInfo, error) {
 		protocol := strings.ToLower(fields[0])
 		state := fields[1]
 
-		// Parse local address
-		localAddrParts := strings.Split(fields[4], ":")
-		if len(localAddrParts) < 2 {
+		// Parse local address (tolerates IPv6 forms such as "[::]:3000").
+		localAddr, localPort, ok := splitHostPort(fields[4])
+		if !ok {
 			continue
 		}
 
-		localAddr := localAddrParts[0]
-		localPort, err := strconv.Atoi(localAddrParts[1])
-		if err != nil {
-			continue
-		}
-
-		// Parse remote address if available
+		// Parse remote address if available (best-effort; peer port is often "*").
 		var remoteAddr string
 		var remotePort int
 		if len(fields) > 5 {
-			remoteAddrParts := strings.Split(fields[5], ":")
-			if len(remoteAddrParts) >= 2 {
-				remoteAddr = remoteAddrParts[0]
-				remotePort, _ = strconv.Atoi(remoteAddrParts[1])
-			}
+			remoteAddr, remotePort, _ = splitHostPort(fields[5])
 		}
 
 		// Extract process name if available
@@ -340,8 +435,15 @@ func getPortsUsingSS(pid int) ([]*PortInfo, error) {
 	return portsInfo, nil
 }
 
-// getChildPIDs returns all child PIDs of a given parent PID (macOS)
+// getChildPIDs returns all descendant PIDs of a given parent PID.
 func getChildPIDs(parentPID int) []int {
+	// Never walk from the process-tree roots: `pgrep -P 0/1` would recursively
+	// enumerate (nearly) every process on the host. Real workload wrappers
+	// always have a concrete PID > 1.
+	if parentPID <= 1 {
+		return []int{}
+	}
+
 	// Use pgrep to find child processes
 	cmd := exec.Command("pgrep", "-P", strconv.Itoa(parentPID))
 	output, err := cmd.Output()
@@ -543,25 +645,14 @@ func getPortsUsingNetstat(pid int) ([]*PortInfo, error) {
 
 		protocol := strings.ToLower(fields[0])
 
-		// Parse local address
-		localAddrParts := strings.Split(fields[3], ":")
-		if len(localAddrParts) < 2 {
+		// Parse local address (tolerates IPv6 forms such as ":::3000").
+		localAddr, localPort, ok := splitHostPort(fields[3])
+		if !ok {
 			continue
 		}
 
-		localAddr := localAddrParts[0]
-		localPort, err := strconv.Atoi(localAddrParts[len(localAddrParts)-1])
-		if err != nil {
-			continue
-		}
-
-		// Parse remote address
-		remoteAddrParts := strings.Split(fields[4], ":")
-		remoteAddr := remoteAddrParts[0]
-		remotePort := 0
-		if len(remoteAddrParts) >= 2 {
-			remotePort, _ = strconv.Atoi(remoteAddrParts[len(remoteAddrParts)-1])
-		}
+		// Parse remote address (best-effort).
+		remoteAddr, remotePort, _ := splitHostPort(fields[4])
 
 		// Parse state
 		state := fields[5]

--- a/sandbox-api/src/handler/network/readiness_test.go
+++ b/sandbox-api/src/handler/network/readiness_test.go
@@ -1,0 +1,129 @@
+package network
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestSplitHostPort(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantHost string
+		wantPort int
+		wantOK   bool
+	}{
+		{"0.0.0.0:3000", "0.0.0.0", 3000, true},
+		{"127.0.0.1:8080", "127.0.0.1", 8080, true},
+		{"*:3000", "*", 3000, true},
+		{"[::]:3000", "::", 3000, true},
+		{":::3000", "::", 3000, true},
+		{"[::1]:3000", "::1", 3000, true},
+		{"[2001:db8::1]:443", "2001:db8::1", 443, true},
+		{"0.0.0.0:*", "", 0, false}, // wildcard peer port is not numeric
+		{"noport", "", 0, false},
+	}
+	for _, c := range cases {
+		host, port, ok := splitHostPort(c.in)
+		if ok != c.wantOK || host != c.wantHost || port != c.wantPort {
+			t.Errorf("splitHostPort(%q) = (%q, %d, %v), want (%q, %d, %v)",
+				c.in, host, port, ok, c.wantHost, c.wantPort, c.wantOK)
+		}
+	}
+}
+
+func TestIsRoutableListener(t *testing.T) {
+	cases := []struct {
+		name string
+		p    *PortInfo
+		want bool
+	}{
+		{"nil", nil, false},
+		{"ipv4 wildcard listen", &PortInfo{LocalAddr: "0.0.0.0", State: "LISTEN"}, true},
+		{"ipv6 wildcard listen", &PortInfo{LocalAddr: "::", State: "LISTEN"}, true},
+		{"star wildcard listen", &PortInfo{LocalAddr: "*", State: "LISTEN"}, true},
+		{"concrete routable ip", &PortInfo{LocalAddr: "10.0.0.5", State: "LISTEN"}, true},
+		{"empty state treated as listen", &PortInfo{LocalAddr: "0.0.0.0", State: ""}, true},
+		{"ipv4 loopback", &PortInfo{LocalAddr: "127.0.0.1", State: "LISTEN"}, false},
+		{"ipv6 loopback", &PortInfo{LocalAddr: "::1", State: "LISTEN"}, false},
+		{"established not listen", &PortInfo{LocalAddr: "0.0.0.0", State: "ESTAB"}, false},
+	}
+	for _, c := range cases {
+		if got := IsRoutableListener(c.p); got != c.want {
+			t.Errorf("%s: IsRoutableListener = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestIsPortReadySubtreeAttribution verifies the core ENG-4284 fix: when a
+// command is wrapped in a shell (`sh -c "... && server"`), the listening socket
+// is owned by a child PID, yet IsPortReady(shellPID, port) must still detect it.
+func TestIsPortReadySubtreeAttribution(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("subtree attribution via ss/pgrep is exercised on linux")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+
+	port := 38731
+	// The listener is a child of the shell: the shell PID owns no socket.
+	cmd := exec.Command("sh", "-c",
+		fmt.Sprintf("sleep 0.3 && exec python3 -m http.server %d --bind 0.0.0.0", port))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	shellPID := cmd.Process.Pid
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if IsPortReady(shellPID, port) {
+			return // success: readiness detected via the child's socket
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("IsPortReady(%d, %d) never became true for shell-wrapped child listener", shellPID, port)
+}
+
+// TestIsPortReadyRejectsLoopbackOnly verifies that a workload bound only to
+// loopback is NOT reported ready, since the edge gateway cannot reach it — even
+// though a bare 127.0.0.1 connect would succeed.
+func TestIsPortReadyRejectsLoopbackOnly(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("relies on ss listener enumeration on linux")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+
+	port := 38732
+	cmd := exec.Command("python3", "-m", "http.server", strconv.Itoa(port), "--bind", "127.0.0.1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	pid := cmd.Process.Pid
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	// Wait until the loopback socket is actually connectable.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) && !isPortOpenByConnect(port) {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !isPortOpenByConnect(port) {
+		t.Skip("loopback server never came up; skipping")
+	}
+
+	if IsPortReady(pid, port) {
+		t.Fatalf("IsPortReady returned true for a loopback-only bind; gateway could not reach it")
+	}
+}

--- a/sandbox-api/src/handler/process/service.go
+++ b/sandbox-api/src/handler/process/service.go
@@ -92,7 +92,13 @@ func (pm *ProcessManager) ExecuteProcess(
 		ports := make([]int, 0, len(waitForPorts))
 		pidInt, _ := strconv.Atoi(pid)
 		n.RegisterPortOpenCallback(pidInt, func(pid int, port *network.PortInfo) {
-			if slices.Contains(waitForPorts, port.LocalPort) {
+			// Only count a port as ready once it is a listening socket bound to a
+			// routable interface. A loopback-only bind is reachable via a local
+			// connect but not through the edge gateway, so it must not satisfy
+			// waitForPorts.
+			if slices.Contains(waitForPorts, port.LocalPort) &&
+				network.IsRoutableListener(port) &&
+				!slices.Contains(ports, port.LocalPort) {
 				ports = append(ports, port.LocalPort)
 			}
 			if len(ports) == len(waitForPorts) {
@@ -125,7 +131,7 @@ func (pm *ProcessManager) ExecuteProcess(
 				case <-ticker.C:
 					allPortsOpen := true
 					for _, port := range waitForPorts {
-						if !network.IsPortOpen(port) {
+						if !network.IsPortReady(pidInt, port) {
 							allPortsOpen = false
 							break
 						}


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR strengthens the `waitForPorts` readiness contract by requiring ports to be listening on a routable interface (not just loopback), and by walking the process subtree so ports opened by child processes (e.g., `sh -c "... && node server.js"`) are correctly attributed. It introduces `IsRoutableListener`, `IsPortReady`, a shared `splitHostPort` helper (with IPv6 support), and corresponding tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit caecc46a9879210f902d410859de3697c7cc26f5.</sup>
<!-- /MENDRAL_SUMMARY -->