### PR TITLE
chore(deps): fix critical/high Dependabot alerts in sandbox

### DIFF
--- a/.github/workflows/dependency-verification.yml
+++ b/.github/workflows/dependency-verification.yml
@@ -40,8 +40,14 @@ jobs:
         working-directory: hub/jupyter-server
         run: |
           # The runner's python is externally managed (PEP 668), so --system is refused.
+          # Two separate installs, in the same order as hub/jupyter-server/Dockerfile,
+          # so this gate resolves the same package set the image actually ships:
+          # a joint `-r requirements.txt -r server/requirements.txt` resolution can
+          # differ from (or fail on a conflict tolerated by) the Dockerfile's
+          # sequential requirements.txt -> server/requirements.txt installs.
           uv venv .venv
-          uv pip install --python .venv -r requirements.txt -r server/requirements.txt
+          uv pip install --python .venv -r requirements.txt
+          uv pip install --python .venv -r server/requirements.txt
 
       - name: Run dependency smoke tests
         working-directory: hub/jupyter-server

--- a/.github/workflows/dependency-verification.yml
+++ b/.github/workflows/dependency-verification.yml
@@ -39,9 +39,11 @@ jobs:
       - name: Install jupyter-server Python dependencies
         working-directory: hub/jupyter-server
         run: |
-          uv pip install --system -r requirements.txt -r server/requirements.txt
+          # The runner's python is externally managed (PEP 668), so --system is refused.
+          uv venv .venv
+          uv pip install --python .venv -r requirements.txt -r server/requirements.txt
 
       - name: Run dependency smoke tests
         working-directory: hub/jupyter-server
         run: |
-          python -m pytest tests/ -v
+          .venv/bin/python -m pytest tests/ -v

--- a/.github/workflows/dependency-verification.yml
+++ b/.github/workflows/dependency-verification.yml
@@ -1,0 +1,47 @@
+name: Dependency verification
+
+# Gate for dependency-bump PRs only: this must not become a mandatory job on
+# every unrelated PR in the repo. GitHub has no title filter in `on:`, so the
+# job itself is gated with `if:` below.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled]
+    paths:
+      - 'hub/jupyter-server/requirements.txt'
+      - 'hub/jupyter-server/server/requirements.txt'
+      - 'hub/jupyter-server/tests/**'
+      - '.github/workflows/dependency-verification.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  jupyter-server-python-deps:
+    # Dependency PRs only: this remediation, Dependabot's own PRs, or an explicit label.
+    if: >-
+      contains(github.event.pull_request.title, 'Dependabot') ||
+      startsWith(github.event.pull_request.title, 'chore(deps)') ||
+      startsWith(github.head_ref, 'cploujoux/devin/dependabot-') ||
+      startsWith(github.head_ref, 'dependabot/') ||
+      contains(github.event.pull_request.labels.*.name, 'dependencies') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: '3.12' # matches hub/jupyter-server/Dockerfile's python:3.12-slim base
+
+      - name: Install jupyter-server Python dependencies
+        working-directory: hub/jupyter-server
+        run: |
+          uv pip install --system -r requirements.txt -r server/requirements.txt
+
+      - name: Run dependency smoke tests
+        working-directory: hub/jupyter-server
+        run: |
+          python -m pytest tests/ -v

--- a/hub/jupyter-server/requirements.txt
+++ b/hub/jupyter-server/requirements.txt
@@ -10,7 +10,7 @@ matplotlib==3.10.3
 pillow==12.3.0
 
 # Other packages
-aiohttp==3.14.1
+aiohttp==3.14.3
 beautifulsoup4==4.13.4
 bokeh==3.9.1
 gensim==4.3.3 # unmaintained, blocking numpy and scipy bump

--- a/hub/jupyter-server/tests/test_aiohttp_smoke.py
+++ b/hub/jupyter-server/tests/test_aiohttp_smoke.py
@@ -1,0 +1,129 @@
+"""Smoke tests for the ``aiohttp`` package shipped in this image's Python
+environment (see ``requirements.txt``).
+
+``aiohttp`` is not imported by our own server code (``server/*.py`` uses
+``httpx`` and ``websockets`` instead) -- it is installed here so that user
+code running *inside* a jupyter-server sandbox can ``import aiohttp`` for
+its own HTTP work. That is the "production" construction path this test
+exercises: a plain ``aiohttp.ClientSession()`` making a real request over a
+loopback socket, exactly as a notebook cell would.
+
+Bumped for GHSA-cq5v-8q36-5273 / CVE-2026-69244 (aiohttp 3.14.1 -> 3.14.3):
+an out-of-bounds heap read in the C HTTP response parser's error-message
+construction, triggered by a malformed chunked response. The second test
+below feeds the exact malformed bodies from aiohttp's own upstream
+regression suite (aio-libs/aiohttp PR #13223) through a real client/server
+round trip.
+
+Note on the revert-check: re-running this test against aiohttp==3.14.1
+produced byte-identical output to 3.14.3 across repeated runs (see the
+remediation report) -- consistent with a heap-layout-dependent OOB read
+that a bare Python process cannot reliably surface without ASan/valgrind.
+The test still pins the exact vulnerable inputs against the real parser on
+every CI run, which is strictly better coverage than the "no test at all"
+baseline this package had before.
+"""
+
+import asyncio
+
+import aiohttp
+import pytest
+
+# Malformed chunked-response bodies from aiohttp's own regression suite for
+# this CVE (aio-libs/aiohttp tests/test_http_parser.py,
+# _BAD_CHUNKED_RESPONSES + _BAD_CHUNKED_RESPONSES_AT_END). The "AT_END"
+# entries place the offending byte at the very end of the TCP write, with no
+# trailing CRLF -- the case the unbounded strlen-based slice used to overrun.
+MALFORMED_CHUNKED_BODIES = [
+    b"0\rX\r\n\r\n",
+    b"5\r\nhello\rX\r\n0\r\n\r\n",
+    b"5\r\nhelloXY\r\n0\r\n\r\n",
+    b"1\r\nA\rB\r\n0\r\n\r\n",
+    b"0_2e\r\n\r\n",
+    b"0\rX",
+    b"5\r\nhello\rX",
+    b"0_",
+]
+
+CHUNKED_RESPONSE_HEADER = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+
+
+async def _serve_once(handler):
+    """Start a loopback TCP server that runs ``handler`` for a single
+    connection, and return its base URL."""
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    return server, f"http://127.0.0.1:{port}/"
+
+
+async def _plain_ok_handler(reader, writer):
+    try:
+        await reader.readuntil(b"\r\n\r\n")
+    except asyncio.IncompleteReadError:
+        pass
+    body = b'{"ok": true}'
+    writer.write(
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body
+    )
+    await writer.drain()
+    writer.close()
+
+
+async def _round_trip_get() -> tuple[int, bytes]:
+    server, url = await _serve_once(_plain_ok_handler)
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as resp:
+                return resp.status, await resp.read()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+def test_client_session_round_trip():
+    """Baseline: a notebook-style ``aiohttp.ClientSession().get()`` against a
+    real loopback server works end to end after the bump."""
+    status, body = asyncio.run(_round_trip_get())
+    assert status == 200
+    assert body == b'{"ok": true}'
+
+
+async def _fetch_malformed(body: bytes) -> Exception:
+    async def handler(reader, writer):
+        try:
+            await reader.readuntil(b"\r\n\r\n")
+        except asyncio.IncompleteReadError:
+            pass
+        writer.write(CHUNKED_RESPONSE_HEADER + body)
+        await writer.drain()
+        writer.close()
+
+    server, url = await _serve_once(handler)
+    try:
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises((aiohttp.ClientResponseError, aiohttp.ClientPayloadError)) as exc_info:
+                async with session.get(url) as resp:
+                    await resp.read()
+            return exc_info.value
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.parametrize("body", MALFORMED_CHUNKED_BODIES)
+def test_malformed_chunked_response_raises_clean_error(body: bytes):
+    """Regression test for GHSA-cq5v-8q36-5273 (CVE-2026-69244).
+
+    Feeds a malformed chunked response -- including the "error at buffer
+    end" shapes that used to trigger the OOB read while building the error
+    message -- through a real ``ClientSession`` request. The bump must keep
+    raising a clean, catchable HTTP error; it must never crash the process
+    or hang.
+    """
+    exc = asyncio.run(_fetch_malformed(body))
+    # The parser's error message embeds a repr() of the bad snippet; assert
+    # it is a normal, bounded string rather than something absurdly long
+    # (a symptom of the unbounded strlen the patch removed).
+    assert len(str(exc)) < 500

--- a/hub/jupyter-server/tests/test_aiohttp_smoke.py
+++ b/hub/jupyter-server/tests/test_aiohttp_smoke.py
@@ -122,7 +122,7 @@ def test_malformed_chunked_response_raises_clean_error(body: bytes):
     raising a clean, catchable HTTP error; it must never crash the process
     or hang.
     """
-    exc = asyncio.run(_fetch_malformed(body))
+    exc = asyncio.run(asyncio.wait_for(_fetch_malformed(body), timeout=5.0))
     # The parser's error message embeds a repr() of the bad snippet; assert
     # it is a normal, bounded string rather than something absurdly long
     # (a symptom of the unbounded strlen the patch removed).


### PR DESCRIPTION
Closes the one open high-severity Dependabot alert in this repo: `aiohttp` in the jupyter-server image (GHSA-cq5v-8q36-5273 / CVE-2026-69244).

`hub/jupyter-server/requirements.txt`: **aiohttp 3.14.1 → 3.14.3**. Two point releases, both bugfix-only, no API change. The package is only reachable from the disposable per-user notebook image, not from our own service code.

## How we know it works

`hub/jupyter-server/` had no tests and nothing running on pull requests. Both now exist:

- `tests/test_aiohttp_smoke.py` — real client/server round trip through the new version, plus clean error handling on a malformed chunked response.
- `.github/workflows/dependency-verification.yml` — runs those tests on dependency PRs (job `jupyter-server-python-deps`).

**One thing to be honest about**: the test proves 3.14.3 behaves correctly, but it cannot prove the CVE is gone. The advisory is an out-of-bounds heap read, and whether it is observable depends on what happens to sit in the adjacent memory page. Reproducing it needs ASan or a poisoning allocator, which a plain CPython process does not have. Verified: the same test passes identically on 3.14.1, including when driving the C HTTP parser directly with the malformed bodies from the upstream fix. So the fix rests on the version being past the patched release, not on a failing-then-passing test.

## Residual risk

The notebook image is not exercised end to end here — the gate covers the dependency, not a running Jupyter session.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Bumps aiohttp 3.14.1→3.14.3 in jupyter-server to fix CVE-2026-69244, adds smoke tests with a timeout-bounded malformed-chunked regression test, and a CI workflow gate for dependency PRs using a venv with sequential installs mirroring the Dockerfile.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 36be0d82e40aa978d73349ae2ce99a110374f024.</sup>
<!-- /MENDRAL_SUMMARY -->