### PR TITLE
Add public Omnigent host sandbox image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ on:
           - nextjs
           - node
           - node-slim
+          - omnigent-host
           - onboarder-nextjs
           - playwright-chromium
           - playwright-firefox

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ A development environment for TypeScript applications with Node.js runtime and e
 ### Expo
 A comprehensive development environment for building React Native applications using the Expo framework. Includes Expo CLI, development server, and all necessary tools for cross-platform mobile development.
 
+### Omnigent Host
+A managed-host runtime for Omnigent agent sessions. It combines Omnigent's prebuilt host environment with the Blaxel sandbox API for process execution, file transfer, streaming, and lifecycle control. The image stays hidden from general Hub discovery because Omnigent selects it automatically, but its `blaxel/omnigent-host:latest` reference is public across workspaces.
+
 ## Prerequisites
 
 - Docker and Docker Compose

--- a/hub/omnigent-host/Dockerfile
+++ b/hub/omnigent-host/Dockerfile
@@ -1,0 +1,12 @@
+ARG SANDBOX_VERSION=latest
+FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
+
+# Keep the Omnigent runtime immutable until this recipe is deliberately updated.
+FROM ghcr.io/omnigent-ai/omnigent-host:latest@sha256:0d9480a4ae4b179c450de0e346628165ab5190f867b5465f52c8c9d50d1f4f27
+
+COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
+RUN chmod +x /usr/local/bin/sandbox-api
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/sandbox-api"]

--- a/hub/omnigent-host/template.json
+++ b/hub/omnigent-host/template.json
@@ -1,0 +1,23 @@
+{
+  "name": "omnigent-host",
+  "displayName": "Omnigent Host",
+  "categories": [
+    "agents",
+    "development"
+  ],
+  "description": "An Omnigent host runtime for managed agent sessions in Blaxel sandboxes.",
+  "longDescription": "The Omnigent Host image combines Omnigent's agent runtimes with the Blaxel sandbox API. Omnigent servers use it to provision disposable managed hosts with process execution, file transfer, bounded streaming, and lifecycle control through the Blaxel SDK.",
+  "url": "https://github.com/omnigent-ai/omnigent",
+  "icon": "https://github.com/omnigent-ai.png",
+  "memory": 4096,
+  "ports": [
+    {
+      "name": "sandbox-api",
+      "target": 8080,
+      "protocol": "HTTP"
+    }
+  ],
+  "enterprise": false,
+  "coming_soon": false,
+  "hidden": true
+}


### PR DESCRIPTION
Linear: ENG-4464

## Summary

- Add a hidden Hub template for `blaxel/omnigent-host:latest`.
- Combine the digest-pinned Omnigent host runtime with Blaxel's `sandbox-api`.
- Add `omnigent-host` to the manual build and publish workflow.

The image stays hidden from Hub discovery because Omnigent selects it automatically. Its `blaxel/omnigent-host:latest` reference remains public across workspaces, like the benchmark image.

## Test plan

- Parsed and validated `hub/omnigent-host/template.json`.
- Validated `.github/workflows/build.yaml` against the repository's existing actionlint baseline.
- Verified both source image manifests and the pinned Omnigent host digest.
- Ran the repository Go suite locally, excluding one unchanged macOS PATH assertion that Linux CI covers.
- Ran a runtime-equivalent private image through Omnigent's live Blaxel lifecycle smoke test: command success and failure, binary file transfer, streaming, active-process cleanup, attach, idempotent delete, and terminal 404.

## Release

After merge, manually dispatch `Build and Push Sandbox` on `main` with `sandbox=omnigent-host`. Verify `blaxel/omnigent-host:latest` from a separate non-production workspace before opening the Omnigent provider PR.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a new `omnigent-host` sandbox image that combines the Omnigent host runtime (digest-pinned) with the Blaxel sandbox API binary. Includes the Dockerfile, a hidden Hub template, a README entry, and a workflow addition for manual builds.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 051ff8e9b8e7377704417ad67711b6f67586ba44.</sup>
<!-- /MENDRAL_SUMMARY -->