### PR TITLE
Add Amp sandbox image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,7 @@ on:
         default: ""
         options:
           - all
+          - amp
           - app-runner
           - astro
           - base-image

--- a/hub/amp/Dockerfile
+++ b/hub/amp/Dockerfile
@@ -5,6 +5,7 @@ FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 FROM node:24-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203
 
 ARG AMP_VERSION=0.0.1786305972-ge46792
+ARG AMP_INSTALLER_SHA256=4ceab71af4f5a126d8ffe0e1af3b06f210be67eae93c8e4583793a52064fc2e2
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   bash \
@@ -18,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://ampcode.com/install.sh -o /tmp/install-amp.sh \
+  && echo "${AMP_INSTALLER_SHA256}  /tmp/install-amp.sh" | sha256sum -c - \
   && AMP_HOME=/opt/amp AMP_VERSION="${AMP_VERSION}" NO_COLOR=1 bash /tmp/install-amp.sh \
   && ln -s /opt/amp/bin/amp /usr/local/bin/amp \
   && amp --version | grep -F "${AMP_VERSION}" \

--- a/hub/amp/Dockerfile
+++ b/hub/amp/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
 
 FROM node:24-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203
 
-ARG AMP_VERSION=0.0.1786305972-ge46792
+ARG AMP_VERSION=0.0.1787328285-g05ea44
 ARG AMP_INSTALLER_SHA256=4ceab71af4f5a126d8ffe0e1af3b06f210be67eae93c8e4583793a52064fc2e2
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/hub/amp/Dockerfile
+++ b/hub/amp/Dockerfile
@@ -1,0 +1,35 @@
+ARG SANDBOX_VERSION=latest
+
+FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
+
+FROM node:24-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476489d09f560a203
+
+ARG AMP_VERSION=0.0.1786305972-ge46792
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  bash \
+  ca-certificates \
+  curl \
+  git \
+  gzip \
+  python3 \
+  python-is-python3 \
+  ripgrep \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://ampcode.com/install.sh -o /tmp/install-amp.sh \
+  && AMP_HOME=/opt/amp AMP_VERSION="${AMP_VERSION}" NO_COLOR=1 bash /tmp/install-amp.sh \
+  && ln -s /opt/amp/bin/amp /usr/local/bin/amp \
+  && amp --version | grep -F "${AMP_VERSION}" \
+  && rm /tmp/install-amp.sh
+
+WORKDIR /blaxel
+
+COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
+RUN chmod +x /usr/local/bin/sandbox-api
+
+EXPOSE 8080
+
+ENV HOME=/blaxel
+
+ENTRYPOINT ["/usr/local/bin/sandbox-api"]

--- a/hub/amp/template.json
+++ b/hub/amp/template.json
@@ -1,0 +1,23 @@
+{
+  "name": "amp",
+  "displayName": "Amp",
+  "categories": [
+    "agents",
+    "development"
+  ],
+  "description": "A sandbox image with Amp pre-installed for agentic coding workflows.",
+  "longDescription": "The Amp sandbox image provides a Blaxel sandbox runtime with Amp installed and available on PATH as `amp`. Use it to create SDK-managed sandboxes where Amp can inspect repositories, run commands, stream structured output, and continue threads after the sandbox resumes from standby.",
+  "url": "https://ampcode.com/manual",
+  "icon": "https://blaxel.ai/logo.png",
+  "memory": 8192,
+  "ports": [
+    {
+      "name": "sandbox-api",
+      "target": 8080,
+      "protocol": "HTTP"
+    }
+  ],
+  "enterprise": false,
+  "coming_soon": false,
+  "hidden": true
+}


### PR DESCRIPTION
## Summary

- add a hidden Amp sandbox image built on the standard Blaxel sandbox API
- install a pinned Amp CLI through a checksum-verified copy of Amp's official installer
- include Git, Python, and ripgrep for coding workflows
- add Amp to the manual sandbox build selector

## Why

This gives Blaxel a provider-owned Amp runtime path comparable to the existing Codex and Claude Code sandbox images. Users can start Amp without installing the CLI during each sandbox session.

## Verification

- built the image for `linux/amd64`
- verified the pinned installer checksum before execution
- verified the pinned Amp version, Python, Git, ripgrep, and sandbox API binary
- started the image and passed the sandbox API health check
- ran a live Amp task in a Blaxel sandbox with structured output
- put the sandbox in standby, reconnected through a new SDK instance, and continued the same Amp thread
- verified the exact repository changes after continuation

## Release gate

This PR prepares the image but keeps the template hidden. Do not publish or unhide the image until ENG-4628 records Amp's written permission for image redistribution and branding.

No Amp outreach is included in this PR.

Linear: ENG-4614, ENG-4629

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a hidden Amp sandbox image with pinned Amp CLI version, SHA-256 checksum verification of the installer script, and standard sandbox-api entrypoint. Includes workflow selector entry and template metadata.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e57408bdbb0705e6b0af974a88f19c12b59e7927.</sup>
<!-- /MENDRAL_SUMMARY -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-time download and execution of a third-party installer (checksum-pinned) plus a new hub image. Exposure is limited because the template remains hidden and is not published yet.
> 
> **Overview**
> Adds a **hidden** Amp sandbox image so SDK-managed sandboxes can run a pinned Amp CLI without installing it at session start.
> 
> The image follows the existing agent-sandbox pattern (`sandbox-api` on Node 24 slim, Git/Python/ripgrep). Amp is installed from Amp’s official installer after a SHA-256 check, then version-verified and put on PATH as `amp`. The template stays `hidden: true` until redistribution/branding permission is recorded. Manual workflow dispatch now includes `amp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d510f57fcc0c7d4725a389c6cfefc86b98e38ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->