### PR TITLE
feat(hub): add Tailscale sandbox image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ on:
           - playwright-firefox
           - py-app
           - ts-app
+          - tailscale
           - vite
           - xfce-vnc
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,16 @@ services:
       - "8080:8080"
       - "3010:3010"
 
+  tailscale:
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: hub/tailscale/Dockerfile
+    env_file:
+      - .env
+    ports:
+      - "8080:8080"
+
   app-runner:
     platform: linux/amd64
     build:

--- a/hub/tailscale/Dockerfile
+++ b/hub/tailscale/Dockerfile
@@ -1,0 +1,17 @@
+ARG SANDBOX_VERSION=latest
+FROM ghcr.io/blaxel-ai/sandbox:${SANDBOX_VERSION} AS sandbox-api
+
+FROM tailscale/tailscale:stable
+
+COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
+COPY hub/tailscale/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+ENV TS_EXTRA_ARGS=--ssh \
+    TS_STATE_DIR=/var/lib/tailscale \
+    TS_USERSPACE=true
+
+EXPOSE 8080
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/hub/tailscale/Dockerfile
+++ b/hub/tailscale/Dockerfile
@@ -6,7 +6,7 @@ FROM tailscale/tailscale:stable
 COPY --from=sandbox-api /sandbox-api /usr/local/bin/sandbox-api
 COPY hub/tailscale/entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /entrypoint.sh
+RUN apk add --no-cache bash && chmod +x /entrypoint.sh
 
 ENV TS_EXTRA_ARGS=--ssh \
     TS_STATE_DIR=/var/lib/tailscale \

--- a/hub/tailscale/entrypoint.sh
+++ b/hub/tailscale/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 
 if [ -z "${TS_AUTHKEY:-}" ]; then

--- a/hub/tailscale/entrypoint.sh
+++ b/hub/tailscale/entrypoint.sh
@@ -17,15 +17,17 @@ containerboot_pid=$!
 sandbox_api_pid=
 
 cleanup() {
+  signal=${1:-TERM}
   trap - EXIT INT TERM
-  kill "$containerboot_pid" 2>/dev/null || true
+  kill -s "$signal" "$containerboot_pid" 2>/dev/null || true
   if [ -n "$sandbox_api_pid" ]; then
-    kill "$sandbox_api_pid" 2>/dev/null || true
+    kill -s "$signal" "$sandbox_api_pid" 2>/dev/null || true
     wait "$sandbox_api_pid" 2>/dev/null || true
   fi
   wait "$containerboot_pid" 2>/dev/null || true
 }
-trap 'cleanup; exit 143' INT TERM
+trap 'cleanup INT; exit 130' INT
+trap 'cleanup TERM; exit 143' TERM
 trap cleanup EXIT
 
 elapsed=0

--- a/hub/tailscale/entrypoint.sh
+++ b/hub/tailscale/entrypoint.sh
@@ -8,5 +8,16 @@ fi
 
 export TS_HOSTNAME="${TS_HOSTNAME:-${SANDBOX_NAME:-${BL_NAME:-tailscale-sandbox}}}"
 
-/usr/local/bin/sandbox-api &
-exec /usr/local/bin/containerboot
+containerboot &
+containerboot_pid=$!
+
+until tailscale --socket="${TS_SOCKET:-/tmp/tailscaled.sock}" status --json 2>/dev/null | grep -q '"BackendState": *"Running"'; do
+  if ! kill -0 "$containerboot_pid" 2>/dev/null; then
+    echo "Tailscale stopped before connecting this sandbox" >&2
+    wait "$containerboot_pid"
+    exit 1
+  fi
+  sleep 1
+done
+
+exec sandbox-api

--- a/hub/tailscale/entrypoint.sh
+++ b/hub/tailscale/entrypoint.sh
@@ -14,6 +14,20 @@ esac
 
 containerboot &
 containerboot_pid=$!
+sandbox_api_pid=
+
+cleanup() {
+  trap - EXIT INT TERM
+  kill "$containerboot_pid" 2>/dev/null || true
+  if [ -n "$sandbox_api_pid" ]; then
+    kill "$sandbox_api_pid" 2>/dev/null || true
+    wait "$sandbox_api_pid" 2>/dev/null || true
+  fi
+  wait "$containerboot_pid" 2>/dev/null || true
+}
+trap 'cleanup; exit 143' INT TERM
+trap cleanup EXIT
+
 elapsed=0
 
 until tailscale --socket="${TS_SOCKET:-/tmp/tailscaled.sock}" status --json 2>/dev/null | grep -q '"BackendState": *"Running"'; do
@@ -34,13 +48,6 @@ done
 
 sandbox-api &
 sandbox_api_pid=$!
-
-cleanup() {
-  trap - EXIT INT TERM
-  kill "$containerboot_pid" "$sandbox_api_pid" 2>/dev/null || true
-  wait "$containerboot_pid" "$sandbox_api_pid" 2>/dev/null || true
-}
-trap cleanup EXIT INT TERM
 
 set +e
 wait -n "$containerboot_pid" "$sandbox_api_pid"

--- a/hub/tailscale/entrypoint.sh
+++ b/hub/tailscale/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${TS_AUTHKEY:-}" ]; then
+  echo "TS_AUTHKEY is required to connect this sandbox to Tailscale" >&2
+  exit 1
+fi
+
+export TS_HOSTNAME="${TS_HOSTNAME:-${SANDBOX_NAME:-${BL_NAME:-tailscale-sandbox}}}"
+
+/usr/local/bin/sandbox-api &
+exec /usr/local/bin/containerboot

--- a/hub/tailscale/entrypoint.sh
+++ b/hub/tailscale/entrypoint.sh
@@ -7,9 +7,14 @@ if [ -z "${TS_AUTHKEY:-}" ]; then
 fi
 
 export TS_HOSTNAME="${TS_HOSTNAME:-${SANDBOX_NAME:-${BL_NAME:-tailscale-sandbox}}}"
+startup_timeout=${TS_STARTUP_TIMEOUT_SECONDS:-60}
+case "$startup_timeout" in
+  ''|*[!0-9]*) echo "TS_STARTUP_TIMEOUT_SECONDS must be a non-negative integer" >&2; exit 1 ;;
+esac
 
 containerboot &
 containerboot_pid=$!
+elapsed=0
 
 until tailscale --socket="${TS_SOCKET:-/tmp/tailscaled.sock}" status --json 2>/dev/null | grep -q '"BackendState": *"Running"'; do
   if ! kill -0 "$containerboot_pid" 2>/dev/null; then
@@ -17,7 +22,28 @@ until tailscale --socket="${TS_SOCKET:-/tmp/tailscaled.sock}" status --json 2>/d
     wait "$containerboot_pid"
     exit 1
   fi
+  if [ "$elapsed" -ge "$startup_timeout" ]; then
+    echo "Tailscale did not connect within ${startup_timeout} seconds" >&2
+    kill "$containerboot_pid" 2>/dev/null || true
+    wait "$containerboot_pid" 2>/dev/null || true
+    exit 1
+  fi
   sleep 1
+  elapsed=$((elapsed + 1))
 done
 
-exec sandbox-api
+sandbox-api &
+sandbox_api_pid=$!
+
+cleanup() {
+  trap - EXIT INT TERM
+  kill "$containerboot_pid" "$sandbox_api_pid" 2>/dev/null || true
+  wait "$containerboot_pid" "$sandbox_api_pid" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+set +e
+wait -n "$containerboot_pid" "$sandbox_api_pid"
+status=$?
+set -e
+exit "$status"

--- a/hub/tailscale/entrypoint_test.sh
+++ b/hub/tailscale/entrypoint_test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+entrypoint=$(CDPATH= cd -- "$(dirname "$0")" && pwd)/entrypoint.sh
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+if output=$(env -u TS_AUTHKEY sh "$entrypoint" 2>&1); then
+  echo "entrypoint accepted a missing TS_AUTHKEY" >&2
+  exit 1
+fi
+case "$output" in
+  *"TS_AUTHKEY is required"*) ;;
+  *) echo "entrypoint did not explain the missing TS_AUTHKEY" >&2; exit 1 ;;
+esac
+
+cat >"$tmp/containerboot" <<'EOF'
+#!/bin/sh
+sleep 1
+EOF
+cat >"$tmp/tailscale" <<'EOF'
+#!/bin/sh
+printf '%s\n' '{"BackendState": "Running"}'
+EOF
+cat >"$tmp/sandbox-api" <<'EOF'
+#!/bin/sh
+test "$TS_HOSTNAME" = "test-sandbox"
+EOF
+chmod +x "$tmp/containerboot" "$tmp/tailscale" "$tmp/sandbox-api"
+
+PATH="$tmp:$PATH" TS_AUTHKEY=test BL_NAME=test-sandbox sh "$entrypoint"

--- a/hub/tailscale/entrypoint_test.sh
+++ b/hub/tailscale/entrypoint_test.sh
@@ -7,8 +7,14 @@ entrypoint=$(CDPATH= cd -- "$(dirname "$0")" && pwd)/entrypoint.sh
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
+# Multi-process wait supervision requires Bash rather than BusyBox ash.
+if [ "$(head -n 1 "$entrypoint")" != '#!/bin/bash' ]; then
+  echo "entrypoint must run with Bash" >&2
+  exit 1
+fi
+
 # A sandbox cannot join a tailnet without an auth key, so fail before starting services.
-if output=$(env -u TS_AUTHKEY sh "$entrypoint" 2>&1); then
+if output=$(env -u TS_AUTHKEY bash "$entrypoint" 2>&1); then
   echo "entrypoint accepted a missing TS_AUTHKEY" >&2
   exit 1
 fi
@@ -33,7 +39,7 @@ test "$TS_HOSTNAME" = "test-sandbox"
 EOF
 chmod +x "$tmp/containerboot" "$tmp/tailscale" "$tmp/sandbox-api"
 
-PATH="$tmp:$PATH" TS_AUTHKEY=test BL_NAME=test-sandbox sh "$entrypoint"
+PATH="$tmp:$PATH" TS_AUTHKEY=test BL_NAME=test-sandbox bash "$entrypoint"
 
 # If containerboot exits before Tailscale is ready, surface that failure instead of waiting.
 cat >"$tmp/containerboot" <<'EOF'
@@ -44,7 +50,7 @@ cat >"$tmp/tailscale" <<'EOF'
 #!/bin/sh
 printf '%s\n' '{"BackendState": "NeedsLogin"}'
 EOF
-if output=$(PATH="$tmp:$PATH" TS_AUTHKEY=test sh "$entrypoint" 2>&1); then
+if output=$(PATH="$tmp:$PATH" TS_AUTHKEY=test bash "$entrypoint" 2>&1); then
   echo "entrypoint ignored containerboot failure" >&2
   exit 1
 fi
@@ -58,7 +64,7 @@ cat >"$tmp/containerboot" <<'EOF'
 #!/bin/sh
 sleep 5
 EOF
-if output=$(PATH="$tmp:$PATH" TS_AUTHKEY=test TS_STARTUP_TIMEOUT_SECONDS=0 sh "$entrypoint" 2>&1); then
+if output=$(PATH="$tmp:$PATH" TS_AUTHKEY=test TS_STARTUP_TIMEOUT_SECONDS=0 bash "$entrypoint" 2>&1); then
   echo "entrypoint ignored the startup timeout" >&2
   exit 1
 fi
@@ -73,7 +79,7 @@ cat >"$tmp/containerboot" <<'EOF'
 echo $$ >"$TEST_CHILD_PID_FILE"
 sleep 5
 EOF
-TEST_CHILD_PID_FILE="$tmp/child.pid" PATH="$tmp:$PATH" TS_AUTHKEY=test sh "$entrypoint" &
+TEST_CHILD_PID_FILE="$tmp/child.pid" PATH="$tmp:$PATH" TS_AUTHKEY=test bash "$entrypoint" &
 entrypoint_pid=$!
 attempts=0
 # Wait only long enough to prove containerboot started; never let a failed test hang.
@@ -102,7 +108,7 @@ fi
 cat >"$tmp/containerboot" <<'EOF'
 #!/bin/sh
 sleep 1
-exit 1
+exit 23
 EOF
 cat >"$tmp/tailscale" <<'EOF'
 #!/bin/sh
@@ -110,9 +116,68 @@ printf '%s\n' '{"BackendState": "Running"}'
 EOF
 cat >"$tmp/sandbox-api" <<'EOF'
 #!/bin/sh
-sleep 5
+echo $$ >"$TEST_SURVIVOR_PID_FILE"
+exec sleep 10
 EOF
-if PATH="$tmp:$PATH" TS_AUTHKEY=test sh "$entrypoint"; then
-  echo "entrypoint ignored post-readiness Tailscale failure" >&2
+TEST_SURVIVOR_PID_FILE="$tmp/sandbox-api.pid" PATH="$tmp:$PATH" TS_AUTHKEY=test bash "$entrypoint" &
+entrypoint_pid=$!
+attempts=0
+while kill -0 "$entrypoint_pid" 2>/dev/null && [ "$attempts" -lt 4 ]; do
+  attempts=$((attempts + 1))
+  sleep 1
+done
+if kill -0 "$entrypoint_pid" 2>/dev/null; then
+  kill "$entrypoint_pid" 2>/dev/null || true
+  wait "$entrypoint_pid" 2>/dev/null || true
+  echo "entrypoint waited for sandbox-api after Tailscale failed" >&2
+  exit 1
+fi
+set +e
+wait "$entrypoint_pid"
+status=$?
+set -e
+if [ "$status" -ne 23 ]; then
+  echo "entrypoint returned $status instead of Tailscale status 23" >&2
+  exit 1
+fi
+if kill -0 "$(cat "$tmp/sandbox-api.pid")" 2>/dev/null; then
+  echo "entrypoint left sandbox-api running after Tailscale failed" >&2
+  exit 1
+fi
+
+# The same supervision rule applies when sandbox-api exits before Tailscale.
+cat >"$tmp/containerboot" <<'EOF'
+#!/bin/sh
+echo $$ >"$TEST_SURVIVOR_PID_FILE"
+exec sleep 10
+EOF
+cat >"$tmp/sandbox-api" <<'EOF'
+#!/bin/sh
+sleep 1
+exit 24
+EOF
+TEST_SURVIVOR_PID_FILE="$tmp/containerboot.pid" PATH="$tmp:$PATH" TS_AUTHKEY=test bash "$entrypoint" &
+entrypoint_pid=$!
+attempts=0
+while kill -0 "$entrypoint_pid" 2>/dev/null && [ "$attempts" -lt 4 ]; do
+  attempts=$((attempts + 1))
+  sleep 1
+done
+if kill -0 "$entrypoint_pid" 2>/dev/null; then
+  kill "$entrypoint_pid" 2>/dev/null || true
+  wait "$entrypoint_pid" 2>/dev/null || true
+  echo "entrypoint waited for Tailscale after sandbox-api failed" >&2
+  exit 1
+fi
+set +e
+wait "$entrypoint_pid"
+status=$?
+set -e
+if [ "$status" -ne 24 ]; then
+  echo "entrypoint returned $status instead of sandbox-api status 24" >&2
+  exit 1
+fi
+if kill -0 "$(cat "$tmp/containerboot.pid")" 2>/dev/null; then
+  echo "entrypoint left Tailscale running after sandbox-api failed" >&2
   exit 1
 fi

--- a/hub/tailscale/entrypoint_test.sh
+++ b/hub/tailscale/entrypoint_test.sh
@@ -67,7 +67,17 @@ sleep 5
 EOF
 TEST_CHILD_PID_FILE="$tmp/child.pid" PATH="$tmp:$PATH" TS_AUTHKEY=test sh "$entrypoint" &
 entrypoint_pid=$!
-while [ ! -s "$tmp/child.pid" ]; do sleep 1; done
+attempts=0
+while [ ! -s "$tmp/child.pid" ]; do
+  if ! kill -0 "$entrypoint_pid" 2>/dev/null || [ "$attempts" -ge 5 ]; then
+    kill "$entrypoint_pid" 2>/dev/null || true
+    wait "$entrypoint_pid" 2>/dev/null || true
+    echo "entrypoint did not start containerboot" >&2
+    exit 1
+  fi
+  attempts=$((attempts + 1))
+  sleep 1
+done
 kill -TERM "$entrypoint_pid"
 if wait "$entrypoint_pid"; then
   echo "entrypoint ignored a startup termination signal" >&2

--- a/hub/tailscale/entrypoint_test.sh
+++ b/hub/tailscale/entrypoint_test.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -eu
 
+# Resolve the production entrypoint relative to this file so any working directory works.
 entrypoint=$(CDPATH= cd -- "$(dirname "$0")" && pwd)/entrypoint.sh
+# Keep fake binaries and PID files isolated, then remove them on every exit path.
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
@@ -96,7 +98,7 @@ if kill -0 "$(cat "$tmp/child.pid")" 2>/dev/null; then
   exit 1
 fi
 
-# Tailscale is still required after readiness; its later failure must stop the sandbox API.
+# Tailscale is still required after readiness; its later failure must fail the entrypoint.
 cat >"$tmp/containerboot" <<'EOF'
 #!/bin/sh
 sleep 1

--- a/hub/tailscale/entrypoint_test.sh
+++ b/hub/tailscale/entrypoint_test.sh
@@ -5,6 +5,7 @@ entrypoint=$(CDPATH= cd -- "$(dirname "$0")" && pwd)/entrypoint.sh
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
+# A sandbox cannot join a tailnet without an auth key, so fail before starting services.
 if output=$(env -u TS_AUTHKEY sh "$entrypoint" 2>&1); then
   echo "entrypoint accepted a missing TS_AUTHKEY" >&2
   exit 1
@@ -14,6 +15,8 @@ case "$output" in
   *) echo "entrypoint did not explain the missing TS_AUTHKEY" >&2; exit 1 ;;
 esac
 
+# Shadow the real binaries through PATH so the entrypoint can be tested without Tailscale.
+# This happy path also proves that BL_NAME becomes the default Tailscale hostname.
 cat >"$tmp/containerboot" <<'EOF'
 #!/bin/sh
 sleep 1
@@ -30,6 +33,7 @@ chmod +x "$tmp/containerboot" "$tmp/tailscale" "$tmp/sandbox-api"
 
 PATH="$tmp:$PATH" TS_AUTHKEY=test BL_NAME=test-sandbox sh "$entrypoint"
 
+# If containerboot exits before Tailscale is ready, surface that failure instead of waiting.
 cat >"$tmp/containerboot" <<'EOF'
 #!/bin/sh
 exit 1
@@ -47,6 +51,7 @@ case "$output" in
   *) echo "entrypoint did not explain containerboot failure" >&2; exit 1 ;;
 esac
 
+# Bound startup when containerboot stays alive but Tailscale never reaches Running.
 cat >"$tmp/containerboot" <<'EOF'
 #!/bin/sh
 sleep 5
@@ -60,6 +65,7 @@ case "$output" in
   *) echo "entrypoint did not explain the startup timeout" >&2; exit 1 ;;
 esac
 
+# A termination signal during startup must reach containerboot and leave no child behind.
 cat >"$tmp/containerboot" <<'EOF'
 #!/bin/sh
 echo $$ >"$TEST_CHILD_PID_FILE"
@@ -68,6 +74,7 @@ EOF
 TEST_CHILD_PID_FILE="$tmp/child.pid" PATH="$tmp:$PATH" TS_AUTHKEY=test sh "$entrypoint" &
 entrypoint_pid=$!
 attempts=0
+# Wait only long enough to prove containerboot started; never let a failed test hang.
 while [ ! -s "$tmp/child.pid" ]; do
   if ! kill -0 "$entrypoint_pid" 2>/dev/null || [ "$attempts" -ge 5 ]; then
     kill "$entrypoint_pid" 2>/dev/null || true
@@ -78,6 +85,7 @@ while [ ! -s "$tmp/child.pid" ]; do
   attempts=$((attempts + 1))
   sleep 1
 done
+# Signal the supervisor, then verify both its exit status and child cleanup.
 kill -TERM "$entrypoint_pid"
 if wait "$entrypoint_pid"; then
   echo "entrypoint ignored a startup termination signal" >&2
@@ -88,6 +96,7 @@ if kill -0 "$(cat "$tmp/child.pid")" 2>/dev/null; then
   exit 1
 fi
 
+# Tailscale is still required after readiness; its later failure must stop the sandbox API.
 cat >"$tmp/containerboot" <<'EOF'
 #!/bin/sh
 sleep 1

--- a/hub/tailscale/entrypoint_test.sh
+++ b/hub/tailscale/entrypoint_test.sh
@@ -62,6 +62,24 @@ esac
 
 cat >"$tmp/containerboot" <<'EOF'
 #!/bin/sh
+echo $$ >"$TEST_CHILD_PID_FILE"
+sleep 5
+EOF
+TEST_CHILD_PID_FILE="$tmp/child.pid" PATH="$tmp:$PATH" TS_AUTHKEY=test sh "$entrypoint" &
+entrypoint_pid=$!
+while [ ! -s "$tmp/child.pid" ]; do sleep 1; done
+kill -TERM "$entrypoint_pid"
+if wait "$entrypoint_pid"; then
+  echo "entrypoint ignored a startup termination signal" >&2
+  exit 1
+fi
+if kill -0 "$(cat "$tmp/child.pid")" 2>/dev/null; then
+  echo "entrypoint left containerboot running after termination" >&2
+  exit 1
+fi
+
+cat >"$tmp/containerboot" <<'EOF'
+#!/bin/sh
 sleep 1
 exit 1
 EOF

--- a/hub/tailscale/entrypoint_test.sh
+++ b/hub/tailscale/entrypoint_test.sh
@@ -29,3 +29,51 @@ EOF
 chmod +x "$tmp/containerboot" "$tmp/tailscale" "$tmp/sandbox-api"
 
 PATH="$tmp:$PATH" TS_AUTHKEY=test BL_NAME=test-sandbox sh "$entrypoint"
+
+cat >"$tmp/containerboot" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+cat >"$tmp/tailscale" <<'EOF'
+#!/bin/sh
+printf '%s\n' '{"BackendState": "NeedsLogin"}'
+EOF
+if output=$(PATH="$tmp:$PATH" TS_AUTHKEY=test sh "$entrypoint" 2>&1); then
+  echo "entrypoint ignored containerboot failure" >&2
+  exit 1
+fi
+case "$output" in
+  *"Tailscale stopped before connecting"*) ;;
+  *) echo "entrypoint did not explain containerboot failure" >&2; exit 1 ;;
+esac
+
+cat >"$tmp/containerboot" <<'EOF'
+#!/bin/sh
+sleep 5
+EOF
+if output=$(PATH="$tmp:$PATH" TS_AUTHKEY=test TS_STARTUP_TIMEOUT_SECONDS=0 sh "$entrypoint" 2>&1); then
+  echo "entrypoint ignored the startup timeout" >&2
+  exit 1
+fi
+case "$output" in
+  *"Tailscale did not connect within 0 seconds"*) ;;
+  *) echo "entrypoint did not explain the startup timeout" >&2; exit 1 ;;
+esac
+
+cat >"$tmp/containerboot" <<'EOF'
+#!/bin/sh
+sleep 1
+exit 1
+EOF
+cat >"$tmp/tailscale" <<'EOF'
+#!/bin/sh
+printf '%s\n' '{"BackendState": "Running"}'
+EOF
+cat >"$tmp/sandbox-api" <<'EOF'
+#!/bin/sh
+sleep 5
+EOF
+if PATH="$tmp:$PATH" TS_AUTHKEY=test sh "$entrypoint"; then
+  echo "entrypoint ignored post-readiness Tailscale failure" >&2
+  exit 1
+fi

--- a/hub/tailscale/template.json
+++ b/hub/tailscale/template.json
@@ -1,0 +1,22 @@
+{
+  "name": "tailscale",
+  "displayName": "Tailscale",
+  "categories": ["devops"],
+  "description": "A sandbox connected to your Tailscale network with SSH access enabled.",
+  "longDescription": "The Tailscale sandbox connects to your tailnet automatically at startup and enables Tailscale SSH. Provide your Tailscale authentication key in the TS_AUTHKEY environment variable when creating the sandbox.",
+  "url": "https://tailscale.com/",
+  "icon": "https://avatars.githubusercontent.com/u/48932923?s=200&v=4",
+  "memory": 4096,
+  "ports": [
+    {
+      "name": "sandbox-api",
+      "target": 8080,
+      "protocol": "HTTP"
+    }
+  ],
+  "build": {
+    "slim": false
+  },
+  "enterprise": false,
+  "coming_soon": false
+}


### PR DESCRIPTION
## Summary

Add a ready-to-use Tailscale sandbox image. The image reads `TS_AUTHKEY` at run time, uses userspace networking, enables Tailscale SSH, and starts the Sandbox API after Tailscale is ready.

The latest commit fixes process supervision under Alpine. The image now installs Bash so `wait -n` returns when the first managed process exits.

Related issue: [ENG-2454](https://linear.app/blaxel/issue/ENG-2454)

## User Impact

Users can create a sandbox that joins their tailnet without enabling a TUN device or the `iptables` kernel option. If Tailscale or the Sandbox API stops after readiness, the entrypoint stops the other process and returns the first process exit status.

## Verification

- `bash hub/tailscale/entrypoint_test.sh`
- `bash -n hub/tailscale/entrypoint.sh hub/tailscale/entrypoint_test.sh`
- `docker build --platform linux/amd64 -f hub/tailscale/Dockerfile -t eng-2454-tailscale:cursor-fix .`
- Ran `entrypoint_test.sh` inside the built linux/amd64 image
- `git diff --check origin/main...HEAD`
- Standards and behavior review with no findings
- No auth-key-shaped secrets in the repository diff

## Pre-Ship Validation

Real-tailnet registration, hostname behavior, `tailscale status`, Tailscale SSH, and the tailnet SSH policy still require validation with a valid authentication key. No real key is stored in this PR.

## Review Guide
<!-- review-guide-head: 68e9b15defccea8ff6d334530a13b7b9838e0393 -->

### Why This PR Exists

ENG-2454 requires a sandbox image that can join a Tailscale network at run time. The image requires `TS_AUTHKEY`, enables userspace mode and Tailscale SSH, waits for Tailscale readiness, and supervises both long-running processes.

The latest commit replaces BusyBox `ash` with Bash. Bash `wait -n` detects the first child exit and returns that child's exact status.

### Behavior

- The image uses `tailscale/tailscale:stable` and includes `sandbox-api`.
- The image installs Bash and starts `/entrypoint.sh`.
- `TS_AUTHKEY` is mandatory at run time.
- `TS_USERSPACE=true` enables userspace mode.
- `TS_EXTRA_ARGS=--ssh` enables Tailscale SSH.
- The entrypoint waits for Tailscale state `Running` before it starts `sandbox-api`.
- After readiness, the first child exit controls the entrypoint exit status.
- Exit cleanup stops and waits for the surviving child.

### Execution Flow

```mermaid
flowchart LR
    A[Start entrypoint] --> B{TS_AUTHKEY set}
    B -- No --> C[Exit 1]
    B -- Yes --> D[Start Tailscale]
    D --> E{Tailscale Running}
    E -- No --> F[Wait or timeout]
    E -- Yes --> G[Start sandbox API]
    G --> H[Wait for first child exit]
    H --> I[Save exit status]
    I --> J[Stop survivor]
    J --> K[Exit with saved status]
```

### Invariants And Failure Paths

- A missing `TS_AUTHKEY` prevents both services from starting.
- An invalid startup timeout causes an immediate error.
- `sandbox-api` cannot start before Tailscale reports `Running`.
- A readiness timeout stops and reaps Tailscale.
- `INT` and `TERM` reach both managed children.
- A post-readiness process exit returns its exact status and stops the other process.
- The test harness checks both exit directions with statuses 23 and 24 and verifies survivor cleanup.
- Bash is an explicit image dependency and entrypoint requirement.

### Reading Order

1. `hub/tailscale/template.json` - Review the Store metadata and run-time auth-key requirement.
2. `hub/tailscale/Dockerfile` - Review Bash installation, SSH settings, and userspace mode.
3. `hub/tailscale/entrypoint.sh` - Trace validation, readiness, process supervision, and cleanup.
4. `hub/tailscale/entrypoint_test.sh` - Review lifecycle, exact-status, and survivor-cleanup checks.
5. `.github/workflows/build.yaml` - Confirm image build and publish wiring.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds bash to the Tailscale sandbox image and switches the entrypoint shebang to `#!/bin/bash`, fixing the `wait -n` bug in busybox ash. The test suite is expanded to verify bidirectional process supervision (containerboot dies → sandbox-api is cleaned up, and vice versa) with explicit exit code propagation checks.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 68e9b15defccea8ff6d334530a13b7b9838e0393.</sup>
<!-- /MENDRAL_SUMMARY -->