### PR TITLE
chore(deps): bump nanoid to 3.3.18 in onboarder-nextjs app-template (high)

### DIFF
--- a/.github/workflows/dependency-verification.yml
+++ b/.github/workflows/dependency-verification.yml
@@ -10,6 +10,9 @@ on:
       - 'hub/jupyter-server/requirements.txt'
       - 'hub/jupyter-server/server/requirements.txt'
       - 'hub/jupyter-server/tests/**'
+      - 'hub/onboarder-nextjs/app-template/package.json'
+      - 'hub/onboarder-nextjs/app-template/package-lock.json'
+      - 'hub/onboarder-nextjs/app-template/tests/**'
       - '.github/workflows/dependency-verification.yml'
   workflow_dispatch:
 
@@ -53,3 +56,38 @@ jobs:
         working-directory: hub/jupyter-server
         run: |
           .venv/bin/python -m pytest tests/ -v
+
+  onboarder-nextjs-app-template-npm-deps:
+    # Dependency PRs only: this remediation, Dependabot's own PRs, or an explicit label.
+    if: >-
+      contains(github.event.pull_request.title, 'Dependabot') ||
+      startsWith(github.event.pull_request.title, 'chore(deps)') ||
+      startsWith(github.head_ref, 'cploujoux/devin/dependabot-') ||
+      startsWith(github.head_ref, 'dependabot/') ||
+      contains(github.event.pull_request.labels.*.name, 'dependencies') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24' # matches hub/onboarder-nextjs/Dockerfile's node:24-alpine3.21 base
+
+      - name: Install dependencies (frozen lockfile)
+        working-directory: hub/onboarder-nextjs/app-template
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: hub/onboarder-nextjs/app-template
+        run: npm run typecheck
+
+      - name: Run dependency smoke tests
+        working-directory: hub/onboarder-nextjs/app-template
+        run: npm test
+
+      - name: Build
+        working-directory: hub/onboarder-nextjs/app-template
+        run: npm run build

--- a/hub/onboarder-nextjs/app-template/package-lock.json
+++ b/hub/onboarder-nextjs/app-template/package-lock.json
@@ -754,9 +754,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/hub/onboarder-nextjs/app-template/package.json
+++ b/hub/onboarder-nextjs/app-template/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "sandbox-check": "node scripts/sandbox-check.mjs",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --test 'tests/**/*.test.mjs'"
   },
   "dependencies": {
     "@types/node": "^24.0.0",
@@ -20,7 +21,7 @@
     "typescript": "^5.9.0"
   },
   "overrides": {
-    "nanoid": "3.3.16",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
     "sharp": "0.35.0"
   }

--- a/hub/onboarder-nextjs/app-template/tests/fixtures/nanoid-size-zero.mjs
+++ b/hub/onboarder-nextjs/app-template/tests/fixtures/nanoid-size-zero.mjs
@@ -1,0 +1,8 @@
+// Run out-of-process by tests/nanoid-dos.test.mjs under a timeout: on the
+// vulnerable nanoid build (< 3.3.18) this call never returns (GHSA-2v37-7h3g-55p8).
+import { customAlphabet } from 'nanoid'
+
+const gen = customAlphabet('abcdefghijklmnopqrstuvwxyz', 10)
+const result = gen(0)
+
+process.stdout.write(JSON.stringify({ result }))

--- a/hub/onboarder-nextjs/app-template/tests/nanoid-dos.test.mjs
+++ b/hub/onboarder-nextjs/app-template/tests/nanoid-dos.test.mjs
@@ -1,0 +1,60 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import fs from 'node:fs'
+import { customAlphabet as nonSecureCustomAlphabet } from 'nanoid/non-secure'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.join(__dirname, '..')
+
+// Hang detector, not a performance budget: the vulnerable call never returns
+// at all, so any generous timeout discriminates fixed-vs-vulnerable cleanly.
+const HANG_TIMEOUT_MS = 3000
+
+test('nanoid resolves to a version clearing GHSA-2v37-7h3g-55p8 (>= 3.3.18)', () => {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(ROOT, 'node_modules', 'nanoid', 'package.json'), 'utf8')
+  )
+  const [major, minor, patch] = pkg.version.split('.').map(Number)
+  assert.ok(
+    major > 3 || (major === 3 && (minor > 3 || (minor === 3 && patch >= 18))),
+    `nanoid ${pkg.version} is below the patched floor 3.3.18`
+  )
+})
+
+test("postcss's actual call site (nanoid/non-secure customAlphabet, fixed size 6) still works after the bump", () => {
+  // postcss/lib/input.js does `require('nanoid/non-secure')` and always calls
+  // the generator with a fixed size of 6 -- this repo's only reachable nanoid
+  // entry point, and one the GHSA never touched (its counting loop already
+  // terminates for size 0 in every version). This proves the bump didn't
+  // break the call site production actually reaches.
+  const id = nonSecureCustomAlphabet('abcdefghijklmnopqrstuvwxyz', 6)()
+  assert.equal(id.length, 6)
+})
+
+test('the vulnerable surface (secure customAlphabet/customRandom, size 0) returns immediately instead of hanging', () => {
+  // GHSA-2v37-7h3g-55p8 / CVE-2026-67213: the crypto-backed "nanoid" build
+  // (not the "non-secure" one postcss uses) looped forever on size 0. Nothing
+  // in this repo's tree calls it that way today, but Dependabot flags the
+  // package version regardless of call site, so this proves the shipped fix
+  // itself works rather than trusting the version number alone. Spawned
+  // out-of-process because the bug is a synchronous busy loop that would
+  // otherwise hang the test runner's own thread.
+  const fixture = path.join(__dirname, 'fixtures', 'nanoid-size-zero.mjs')
+  const result = spawnSync(process.execPath, [fixture], {
+    cwd: ROOT,
+    timeout: HANG_TIMEOUT_MS,
+    encoding: 'utf8',
+  })
+
+  assert.notEqual(
+    result.signal,
+    'SIGTERM',
+    'the size=0 call hung past the timeout (vulnerable nanoid version)'
+  )
+  assert.equal(result.status, 0, `fixture exited non-zero: ${result.stderr}`)
+  const output = JSON.parse(result.stdout)
+  assert.equal(output.result, '', 'expected an empty string, not a hang, for size 0')
+})


### PR DESCRIPTION
Fixes ENG-4804

Fixes the repo's one open Dependabot alert: **nanoid, high severity** (GHSA-2v37-7h3g-55p8 / CVE-2026-67213), in `hub/onboarder-nextjs/app-template`. Three older nanoid advisories go with it.

`package.json` already had an override pinning nanoid to **3.3.16 — the vulnerable version itself**, left from an earlier fix. Bumped the override rather than editing the lockfile.

## Proof it actually works

This is the one repo in the batch where the test genuinely discriminates. `tests/nanoid-dos.test.mjs` calls the generator with size 0. Swapping the real vulnerable 3.3.16 tarball back in, the test **hangs until its 3s timeout** and gets killed; with 3.3.18 it returns immediately. Restored, 3/3 pass. That is a real hang-vs-return difference, not a version assertion dressed up as a test.

Worth noting the reachable call site was never at risk: postcss requires `nanoid/non-secure` with a fixed size of 6, and that module is unchanged across all three versions. The vulnerable surface is the separate build, unused here.

## New CI coverage

This manifest had **no pull_request CI at all**. Rather than add a second workflow file, I extended the existing `dependency-verification.yml` with a sibling job that runs `npm ci`, typecheck, the new test, and `next build`.

Also verified the Dockerfile copies exactly this `package.json` and `package-lock.json` before running `npm ci` — so what ships is what was validated.

## Validation

- `npm audit`: 1 high before, 0 after; single resolved copy at 3.3.18
- typecheck, tests, build, `sandbox-check` all green from a clean `npm ci`
- Local Node 24 matches the Dockerfile's `node:24-alpine3.21`

## Separate finding

There is an unpushed local branch `cploujoux/devin/dependabot-moderate-low-sandbox` carrying what looks like real unmerged tier-B work (pytest 8.3.5 → 9.0.3, requests 2.32.4 → 2.33.0 in `hub/jupyter-server`). Out of scope here, left untouched, flagged for a moderate/low pass.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Bumps the nanoid override from 3.3.16 (vulnerable) to 3.3.18 in `hub/onboarder-nextjs/app-template`, adds a smoke test that validates the fix by spawning the vulnerable code path out-of-process with a hang-detecting timeout, and extends the existing `dependency-verification.yml` CI workflow to cover this package.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e07ce5a8738522bec82f45dfb8fe29d088e1c752.</sup>
<!-- /MENDRAL_SUMMARY -->