### PR TITLE
fix(hub): hide tailscale image from store

### DIFF
--- a/hub/tailscale/template.json
+++ b/hub/tailscale/template.json
@@ -18,5 +18,6 @@
     "slim": false
   },
   "enterprise": false,
-  "coming_soon": false
+  "coming_soon": false,
+  "hidden": true
 }


### PR DESCRIPTION
## Summary

Hide the Tailscale sandbox image from Sandbox Hub UI discovery while keeping the published definition available to API and SDK clients.

## Verification

- `jq empty hub/tailscale/template.json`
- `git diff --check origin/main...HEAD`
- Standards review: no findings
- Behavior review: no findings

## Review Guide
<!-- review-guide-head: 7e8834ca672b7df7c917791b9aab85e790fb6310 -->

### Why This PR Exists

Tailscale is an internal sandbox image. Users must not see it in the store UI, but SDK clients must still be able to use it. This PR marks the published Tailscale definition as hidden.

### Behavior

The Tailscale definition now has `"hidden": true`. The publish process keeps this field when it adds the image name and sends the definition to the control plane. The store UI excludes hidden definitions, but the definition stays available through the API and SDK.

### Execution Flow

```mermaid
flowchart LR
  Metadata["Tailscale metadata<br/>hidden: true"] --> Publish["Publisher adds image"]
  Publish --> API["Store API saves definition"]
  API --> List["API returns definition"]
  List --> SDK["SDK can use Tailscale"]
  List --> Filter{"Definition hidden?"}
  Filter -->|Yes| Omit["UI omits Tailscale"]
```

### Invariants And Failure Paths

The publisher must keep `hidden: true`, the Tailscale name, and the other template fields when it adds the image field. A missing required environment variable or template file stops publication. A `curl` transport failure also stops publication. The script does not use `curl --fail`, so an HTTP error response can appear as a successful command.

### Reading Order

1. `hub/tailscale/template.json` - See the hidden metadata and the definition that remains available to clients.
2. `scripts/publish-sandbox.sh` - See how publication keeps the metadata, adds the image field, and sends the full definition.
3. `.github/workflows/build.yaml` - See how the Tailscale definition enters the publish process.
4. `controlplane/app/src/components/store/store.tsx` - See how the store UI excludes definitions that have hidden metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata flag on a hub template with no runtime, auth, or API behavior changes.
> 
> **Overview**
> Marks the Tailscale hub template with **`"hidden": true`**, matching other internal/runtime images so Sandbox Hub **store discovery** no longer lists it.
> 
> The published definition is unchanged for API and SDK clients; only UI catalog visibility is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8834ca672b7df7c917791b9aab85e790fb6310. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `"hidden": true` to the Tailscale sandbox template to hide it from the store UI while keeping it available via API/SDK.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7e8834ca672b7df7c917791b9aab85e790fb6310.</sup>
<!-- /MENDRAL_SUMMARY -->