### PR TITLE
fix(sandbox-api): stop capping long-lived streams at 600s

### DIFF
--- a/sandbox-api/main.go
+++ b/sandbox-api/main.go
@@ -191,15 +191,7 @@ func main() {
 	serverAddr := fmt.Sprintf(":%d", portValue)
 	logrus.Infof("Starting Sandbox API server on %s", serverAddr)
 
-	server := &http.Server{
-		Addr:              serverAddr,
-		Handler:           router,
-		ReadTimeout:       10 * time.Minute, // Allow up to 10 minutes for reading large uploads
-		WriteTimeout:      10 * time.Minute, // Allow up to 10 minutes for writing large downloads
-		ReadHeaderTimeout: 30 * time.Second, // Headers should be quick
-		IdleTimeout:       2 * time.Minute,  // Keep-alive connections timeout
-		MaxHeaderBytes:    1 << 20,          // 1 MB max header size
-	}
+	server := newHTTPServer(serverAddr, router)
 
 	// Set up signal handling for graceful shutdown
 	sigCh := make(chan os.Signal, 1)
@@ -230,6 +222,32 @@ func main() {
 	}
 
 	logrus.Info("Server stopped")
+}
+
+// newHTTPServer builds the API server.
+//
+// ReadTimeout and WriteTimeout are deliberately left at 0 (no deadline). They
+// are NOT idle timeouts: net/http arms them once, when the request starts, and
+// fires them regardless of traffic on the connection. Any non-zero value is
+// therefore a hard cap on the lifetime of every long-lived endpoint we serve:
+//   - GET  /process/:identifier/logs/stream
+//   - POST /process with Accept: text/event-stream
+//   - GET  /watch/filesystem/*path
+//   - GET  /terminal/ws (the deadline outlives the WebSocket hijack)
+//
+// A 10 minute WriteTimeout used to be set here for large file transfers; it cut
+// every one of those streams at exactly 600s while the underlying process kept
+// running, and the 30s "[keepalive]" lines could not prevent it. Slow-client
+// protection is kept where it does not conflict with streaming: ReadHeaderTimeout
+// bounds header slowloris, IdleTimeout bounds idle keep-alive connections.
+func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 30 * time.Second, // Headers should be quick
+		IdleTimeout:       2 * time.Minute,  // Keep-alive connections timeout
+		MaxHeaderBytes:    1 << 20,          // 1 MB max header size
+	}
 }
 
 // startBackgroundCommand runs the given command string in a goroutine using the

--- a/sandbox-api/main_test.go
+++ b/sandbox-api/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bufio"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// The API serves several endpoints that stay open for the whole lifetime of a
+// process or a watch. A non-zero ReadTimeout/WriteTimeout on the server caps
+// that lifetime, so guard the values explicitly.
+func TestNewHTTPServerHasNoStreamKillingTimeouts(t *testing.T) {
+	server := newHTTPServer(":8080", http.NewServeMux())
+
+	if server.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout must stay 0, got %v: it is an absolute deadline armed at request start, "+
+			"so it truncates /process/:identifier/logs/stream and every other long-lived endpoint", server.WriteTimeout)
+	}
+	if server.ReadTimeout != 0 {
+		t.Errorf("ReadTimeout must stay 0, got %v: it kills the read side of hijacked WebSocket "+
+			"connections (/ws/terminal/:name)", server.ReadTimeout)
+	}
+	if server.ReadHeaderTimeout == 0 {
+		t.Error("ReadHeaderTimeout must stay set: it bounds header slowloris without touching streams")
+	}
+}
+
+// Documents the failure mode the constructor guards against: WriteTimeout fires
+// on a stream that never stops producing data, so keepalives cannot save it.
+func TestWriteTimeoutTruncatesLongLivedStream(t *testing.T) {
+	const lines = 10
+	const interval = 100 * time.Millisecond
+
+	// A handler that behaves like the log stream: one line every interval.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		for i := 0; i < lines; i++ {
+			if _, err := w.Write([]byte("line\n")); err != nil {
+				return
+			}
+			w.(http.Flusher).Flush()
+			time.Sleep(interval)
+		}
+	})
+
+	countLines := func(t *testing.T, writeTimeout time.Duration) int {
+		t.Helper()
+		server := httptest.NewUnstartedServer(handler)
+		server.Config.WriteTimeout = writeTimeout
+		server.Start()
+		defer server.Close()
+
+		resp, err := server.Client().Get(server.URL)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		got := 0
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			got++
+		}
+		return got
+	}
+
+	// Half the stream duration: the connection dies mid-stream.
+	if got := countLines(t, lines*interval/2); got >= lines {
+		t.Errorf("expected the stream to be truncated by WriteTimeout, got all %d lines", got)
+	}
+
+	// What newHTTPServer does: the stream runs to completion.
+	if got := countLines(t, 0); got != lines {
+		t.Errorf("expected %d lines without WriteTimeout, got %d", lines, got)
+	}
+}


### PR DESCRIPTION
Fixes ENG-4991

## What

Log streams, exec streams, filesystem watches and the web terminal all die after exactly 600 seconds, even when the process keeps running and data keeps flowing.

## Why

`main.go` set `WriteTimeout: 10 * time.Minute` on the API server. That is not an idle timeout: Go arms it once when the request starts and fires it regardless of traffic. So it is a hard cap on how long any streaming endpoint can stay open. The `[keepalive]` line the log stream sends every 30s cannot prevent it.

Same for `ReadTimeout`, which also outlives the WebSocket hijack and kills the terminal's read side.

Introduced in 72eb2eb (Nov 4, 2025) to support 250MB file transfers. Before that commit the server ran with no timeouts at all, so this is a regression, not a tightening.

Reported by a customer on workspace `floracene`: two processes whose log streams closed at exactly 600s while the processes ran for another 15 minutes.

Affected:
- `GET /process/:identifier/logs/stream`
- `POST /process` with `Accept: text/event-stream`
- `GET /watch/filesystem/*path`
- `GET /terminal/ws`

## Fix

Drop `ReadTimeout` and `WriteTimeout`. Keep the protections that do not conflict with streaming: `ReadHeaderTimeout` (30s, bounds header slowloris) and `IdleTimeout` (2min, bounds idle keep-alive connections).

This is the same fix node-gw already got one layer up, where a 300s total-lifetime timeout was cutting active transfers at 5 minutes and was replaced by an idle backstop.

## Verified

Two binaries, main vs this branch, each streaming `/watch/filesystem` with an event every 15s:

```
main  (10min WriteTimeout): stream cut at exactly 600s, 58 events
fixed (this branch):        still streaming at 780s, 76 events, stopped by the client
```

Plus `sandbox-api/main_test.go`: one test pinning the timeout values, one reproducing the truncation on a real socket with a shortened timeout.

## Not in scope

On reconnect the stream replays the whole log file, but there is a race between reading it and attaching the writer (`src/handler/process/process.go`), so lines written in between are lost. Separate fix.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes `ReadTimeout` and `WriteTimeout` from the HTTP server to fix a regression where long-lived streaming endpoints (log streams, filesystem watches, terminal WebSocket) were hard-capped at 600s regardless of activity. Retains `ReadHeaderTimeout` and `IdleTimeout` for slowloris/idle protection. Adds tests pinning the configuration and demonstrating the truncation failure mode.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 773a38bdf2ec48bf6957eed1abf6cd2bdf603fa2.</sup>
<!-- /MENDRAL_SUMMARY -->