### PR TITLE
fix(drive): platform carries the filer host instead of inferring it

### DIFF
--- a/sandbox-api/src/handler/drive/mount.go
+++ b/sandbox-api/src/handler/drive/mount.go
@@ -378,9 +378,39 @@ func MountDrive(driveName, mountPath, drivePath string, readOnly bool, uidMap, g
 	return "", "", fmt.Errorf("timeout waiting for mount point to be ready after %s", mountTimeout)
 }
 
-// getFilerAddress reads the filer address from /etc/resolv.conf
-// The filer is the first nameserver listed in resolv.conf
+// DriveFilerEnv, when the platform sets it, names the host the Agent Drive filer
+// answers on. A name or an address, and NO port -- formatFilerServerAddress
+// appends SeaweedFS's own host:httpPort.grpcPort form, and must leave an IPv6
+// literal unbracketed there, so a value carrying a port would be ambiguous.
+const DriveFilerEnv = "BL_DRIVE_FILER"
+
+// getFilerAddress returns the host the filer answers on.
+//
+// Two sources, and the order matters. The platform may state the answer via
+// DriveFilerEnv; only if it does not do we fall back to inferring it from
+// /etc/resolv.conf, where the filer is the first nameserver.
+//
+// That inference is correct on mk3.0, where the per-host filer and the DNS
+// resolver are the same host-local thing, so one address genuinely is both. It is
+// wrong on mk3.1, where they are two separate sandboxes: the first nameserver is
+// the CoreDNS resolver, which serves DNS and nothing on 49200, so every mount
+// fails after a 30s timeout.
+//
+// The environment variable rather than resolving a well-known service name here,
+// because neither generation can be detected from inside a sandbox and both
+// alternatives are worse: resolving a name unconditionally breaks mk3.0, where no
+// such name exists, and resolving-then-falling-back reinstates the mk3.1 bug as a
+// silent degraded mode reachable any time DNS is briefly unavailable. The platform
+// knows its own generation; on mk3.1 it sets this, and on mk3.0 it does not.
 func getFilerAddress() (string, error) {
+	if host := strings.TrimSpace(os.Getenv(DriveFilerEnv)); host != "" {
+		logrus.WithFields(logrus.Fields{
+			"filer_address": host,
+			"source":        DriveFilerEnv,
+		}).Debug("Using the filer address supplied by the platform")
+		return host, nil
+	}
+
 	resolvConf, err := os.ReadFile("/etc/resolv.conf")
 	if err != nil {
 		return "", fmt.Errorf("failed to read /etc/resolv.conf: %w", err)

--- a/sandbox-api/src/handler/drive/mount_test.go
+++ b/sandbox-api/src/handler/drive/mount_test.go
@@ -3,6 +3,7 @@ package drive
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -251,5 +252,77 @@ func TestFormatFilerServerAddress(t *testing.T) {
 				t.Fatalf("formatFilerServerAddress(%q) = %q, want %q", tt.address, got, tt.want)
 			}
 		})
+	}
+}
+
+// The platform states the filer host on mk3.1, where inferring it from
+// resolv.conf finds the DNS resolver instead of the filer.
+func TestGetFilerAddressPrefersThePlatformValue(t *testing.T) {
+	t.Setenv(DriveFilerEnv, "agent-drive.svc.blaxel.local")
+
+	got, err := getFilerAddress()
+	if err != nil {
+		t.Fatalf("getFilerAddress() error = %v", err)
+	}
+	if got != "agent-drive.svc.blaxel.local" {
+		t.Fatalf("getFilerAddress() = %q, want the platform-supplied host", got)
+	}
+}
+
+// Whitespace around the value must not become part of the host: it would be
+// appended to SeaweedFS's address string and produce an unresolvable target.
+func TestGetFilerAddressTrimsThePlatformValue(t *testing.T) {
+	t.Setenv(DriveFilerEnv, "  agent-drive.svc.blaxel.local\n")
+
+	got, err := getFilerAddress()
+	if err != nil {
+		t.Fatalf("getFilerAddress() error = %v", err)
+	}
+	if got != "agent-drive.svc.blaxel.local" {
+		t.Fatalf("getFilerAddress() = %q, want it trimmed", got)
+	}
+}
+
+// An empty value is treated as unset, so a platform that exports the variable
+// without a value does not break the mk3.0 path.
+func TestGetFilerAddressIgnoresAnEmptyPlatformValue(t *testing.T) {
+	t.Setenv(DriveFilerEnv, "   ")
+
+	// It must not return the blank value; whether the resolv.conf fallback then
+	// succeeds depends on the machine, which is why that branch is asserted
+	// separately in TestParseFilerAddress.
+	got, _ := getFilerAddress()
+	if got != "" && strings.TrimSpace(got) == "" {
+		t.Fatalf("getFilerAddress() = %q, want a whitespace-only value ignored", got)
+	}
+	if got == "   " {
+		t.Fatal("getFilerAddress() returned the blank environment value verbatim")
+	}
+}
+
+// mk3.0 must be untouched: with the variable unset, the address still comes from
+// resolv.conf. This is the property that makes the change safe to ship to both
+// generations from one binary.
+func TestGetFilerAddressFallsBackToResolvConfWhenUnset(t *testing.T) {
+	if _, ok := os.LookupEnv(DriveFilerEnv); ok {
+		t.Fatalf("%s must be unset for this test", DriveFilerEnv)
+	}
+	// parseFilerAddress is the resolv.conf path getFilerAddress delegates to.
+	got, err := parseFilerAddress([]byte("nameserver 10.0.0.2\n"))
+	if err != nil {
+		t.Fatalf("parseFilerAddress() error = %v", err)
+	}
+	if got != "10.0.0.2" {
+		t.Fatalf("parseFilerAddress() = %q, want the first nameserver", got)
+	}
+}
+
+// A NAME survives SeaweedFS's host:httpPort.grpcPort formatting. Its parser
+// splits the ports on the final '.', computed on the ports substring only, so the
+// dots inside a hostname are not mistaken for the port separator.
+func TestFormatFilerServerAddressAcceptsAName(t *testing.T) {
+	got := formatFilerServerAddress("agent-drive.svc.blaxel.local")
+	if got != "agent-drive.svc.blaxel.local:49200.49201" {
+		t.Fatalf("formatFilerServerAddress() = %q", got)
 	}
 }


### PR DESCRIPTION
Fixes ENG-5044

getFilerAddress infers the filer from /etc/resolv.conf, taking the first nameserver. That is correct on mk3.0, where the per-host filer and the DNS resolver are the same host-local thing, so one address genuinely is both.

It is wrong on mk3.1, where they are two separate sandboxes: the first nameserver is the CoreDNS resolver, which serves DNS and nothing on 49200. Every mount there fails after a 30s timeout, with the resolver's address in the log:

    "msg":"Found filer address from resolv.conf","filer_address":"...a80::1"
    mount_std.go:183 failed to talk to filer [[...a80::1]:49200] ... Unavailable

BL_DRIVE_FILER, when the platform sets it, names the host instead. resolv.conf stays the fallback, so mk3.0 is untouched by construction -- nothing there sets the variable.

Deliberately an environment variable rather than resolving a well-known service name here. Neither generation is detectable from inside a sandbox, and both alternatives are worse: resolving a name unconditionally breaks mk3.0, where no such name exists, and resolving-then-falling-back reinstates the mk3.1 bug as a silent degraded mode reachable any time DNS is briefly unavailable. The platform knows its own generation.

The value is a HOST and carries no port. formatFilerServerAddress appends SeaweedFS's own host:httpPort.grpcPort form and must leave an IPv6 literal unbracketed there, because SeaweedFS splits on the final colon -- so a value carrying a port would be ambiguous for an address even though it reads fine for a name. Verified against the fork's ToHttpAddress/ToGrpcAddress that a NAME survives that formatting: the ports are split on the final '.' of the ports substring only, so the dots inside a hostname are not mistaken for the separator.

Trimmed, and a whitespace-only value is treated as unset, so a platform that exports the variable empty does not break the mk3.0 path.

Mutants caught: checking resolv.conf first, and not trimming.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how drive mounts locate the SeaweedFS filer. Wrong host selection would break mounts, but mk3.0 behavior is preserved when the env var is unset.
> 
> **Overview**
> Fixes Agent Drive mounts on mk3.1, where the first nameserver is CoreDNS rather than the filer, so every mount previously timed out after 30s.
> 
> `getFilerAddress` now prefers a host (no port) from `BL_DRIVE_FILER` when the platform sets it, and only then falls back to `/etc/resolv.conf`. Empty or whitespace-only values are treated as unset so mk3.0 stays on the old path. Tests cover preference, trimming, empty env, fallback, and hostname formatting for SeaweedFS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6934fe66eb604ec46de74682a88989c9130562ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds an environment variable (`BL_DRIVE_FILER`) as the primary source for the filer host address, falling back to the existing resolv.conf inference when unset. This fixes mk3.1 environments where the first nameserver is a CoreDNS resolver rather than the filer.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6934fe66eb604ec46de74682a88989c9130562ed.</sup>
<!-- /MENDRAL_SUMMARY -->