### PR TITLE
chore(deps): bump quic-go to 0.59.1 in sandbox-api

### DIFF
--- a/.github/workflows/dependency-verification.yml
+++ b/.github/workflows/dependency-verification.yml
@@ -25,6 +25,7 @@ jobs:
     if: >-
       contains(github.event.pull_request.title, 'Dependabot') ||
       startsWith(github.event.pull_request.title, 'chore(deps)') ||
+      startsWith(github.head_ref, 'cploujoux/dependabot') ||
       startsWith(github.head_ref, 'cploujoux/devin/dependabot-') ||
       startsWith(github.head_ref, 'dependabot/') ||
       contains(github.event.pull_request.labels.*.name, 'dependencies') ||
@@ -62,6 +63,7 @@ jobs:
     if: >-
       contains(github.event.pull_request.title, 'Dependabot') ||
       startsWith(github.event.pull_request.title, 'chore(deps)') ||
+      startsWith(github.head_ref, 'cploujoux/dependabot') ||
       startsWith(github.head_ref, 'cploujoux/devin/dependabot-') ||
       startsWith(github.head_ref, 'dependabot/') ||
       contains(github.event.pull_request.labels.*.name, 'dependencies') ||

--- a/sandbox-api/go.mod
+++ b/sandbox-api/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/junegunn/fzf v0.74.2
 	github.com/modelcontextprotocol/go-sdk v1.7.0
+	github.com/quic-go/quic-go v0.59.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
@@ -52,7 +53,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/sandbox-api/go.sum
+++ b/sandbox-api/go.sum
@@ -103,8 +103,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/sandbox-api/integration-tests/go.mod
+++ b/sandbox-api/integration-tests/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/sandbox-api/integration-tests/go.sum
+++ b/sandbox-api/integration-tests/go.sum
@@ -73,8 +73,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=

--- a/sandbox-api/src/api/http3_quic_test.go
+++ b/sandbox-api/src/api/http3_quic_test.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/quic-go/quic-go/http3"
+)
+
+// github.com/quic-go/quic-go is linked into the sandbox-api binary because
+// gin imports quic-go/http3 unconditionally (for Engine.RunQUIC, which this
+// repo never calls). This test is what makes the dependency verifiable rather
+// than merely compiled: it stands up the *real* router from SetupRouter behind
+// an HTTP/3 server on loopback UDP, completes a genuine QUIC/TLS 1.3 handshake
+// and round-trips a request, then round-trips response trailers -- the exact
+// surface quic-go 0.59.1 changed (GHSA-vvgj-x9jq-8cj9, HTTP/3 QPACK trailer
+// expansion memory exhaustion; the fix added validation to http3.parseTrailers,
+// which the *client* runs when decoding response trailers).
+//
+// What it proves: the bump did not break the HTTP/3 transport or trailer
+// handling. What it does NOT prove: that the advisory is gone. That is a
+// memory-exhaustion class reachable only from a malicious peer emitting
+// oversized/invalid QPACK trailers, which requires a hand-rolled QPACK writer
+// to reach -- the server's own writeTrailers filters such fields before they
+// hit the wire. Closure of the advisory rests on the version floor plus the
+// go.sum check, not on this test.
+
+// newLoopbackCert mints a self-signed cert for 127.0.0.1. notBefore is a year
+// in the past on purpose: a cert minted "now" fails on any runner with clock
+// skew, and passes locally, which is the worst pairing.
+func newLoopbackCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "sandbox-api-http3-test"},
+		NotBefore:             time.Now().Add(-365 * 24 * time.Hour),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}, pool
+}
+
+func TestHTTP3QUICRoundTripThroughRealRouter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// The production construction path: the same engine main() serves.
+	engine := SetupRouter(true, false)
+
+	// Response trailers are not part of the router's own surface, so the probe
+	// route is added here. It is the only way to drive http3's trailer decoder,
+	// which is the function the 0.59.1 patch rewrote.
+	const trailerKey = "X-Sandbox-Checksum"
+	engine.GET("/__http3_trailer_probe", func(c *gin.Context) {
+		c.Writer.Header().Set("Trailer", trailerKey)
+		c.String(http.StatusOK, "trailer-probe-body")
+		c.Writer.Flush()
+		c.Writer.Header().Set(trailerKey, "deadbeef")
+	})
+
+	cert, pool := newLoopbackCert(t)
+
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	defer udpConn.Close()
+
+	srv := &http3.Server{
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS13},
+		Handler:   engine,
+	}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(udpConn) }()
+	defer srv.Close()
+
+	tr := &http3.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS13},
+	}
+	defer tr.Close()
+	client := &http.Client{Transport: tr}
+
+	base := "https://" + udpConn.LocalAddr().String()
+
+	t.Run("health over QUIC", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/health", nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("QUIC handshake / request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		// Proves the response really came over HTTP/3, not a fallback.
+		if resp.ProtoMajor != 3 {
+			t.Fatalf("proto = %s, want HTTP/3", resp.Proto)
+		}
+		if _, err := io.ReadAll(resp.Body); err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+	})
+
+	t.Run("response trailers decode", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/__http3_trailer_probe", nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if string(body) != "trailer-probe-body" {
+			t.Fatalf("body = %q, want %q", body, "trailer-probe-body")
+		}
+		// Trailers are only populated after the body is fully read.
+		if got := resp.Trailer.Get(trailerKey); got != "deadbeef" {
+			t.Fatalf("trailer %s = %q, want %q (trailers: %v)", trailerKey, got, "deadbeef", resp.Trailer)
+		}
+	})
+
+	srv.Close()
+	select {
+	case <-serveErr:
+	case <-time.After(5 * time.Second):
+		t.Error("http3 server did not shut down")
+	}
+}


### PR DESCRIPTION
Closes both open Dependabot alerts (#133, #134 — same package, two manifests). 1 fixed / 0 skipped / 0 blocked / 0 deferred.

Two evidence bars are used in this sweep. **Tier A** (critical/high) requires a test per bumped package. **Tier B** (moderate/low) requires the CI gate green, plus a per-package test only when the package is reachable from production. This repo has no critical or high alerts. quic-go is linked into the production binary, so it was held to the higher bar and got a real handshake test — not just a green build.

| tier | package | manifest | old → new | severity | advisory | reachable from prod? | test |
|---|---|---|---|---|---|---|---|
| B | github.com/quic-go/quic-go | sandbox-api/go.mod | 0.59.0 → 0.59.1 | moderate | GHSA-vvgj-x9jq-8cj9 | linked into the binary, but the vulnerable path is not | `TestHTTP3QUICRoundTripThroughRealRouter` (new) |
| B | github.com/quic-go/quic-go | sandbox-api/integration-tests/go.mod | 0.59.0 → 0.59.1 | moderate | GHSA-vvgj-x9jq-8cj9 | no, test-only module | same test, same module graph |

## The more useful finding than the bump

**sandbox-api never serves HTTP/3.** It never imports `http3` and never calls `RunQUIC`. quic-go is dead code, linked in only because gin imports it unconditionally. Even on 0.59.0 there was no attacker-reachable trailer parser in this service.

The bump is still correct — it clears the alert and removes the dead vulnerable code from the binary — but nobody should read this PR as having closed a live hole.

## Validation

- New test does a **real QUIC/TLS-1.3 handshake** through the production router, not a mocked transport.
- 0.59.1 is above the `first_patched` of all 8 published quic-go advisories, not just the named one. The release backports one PR: http3 trailer validation.
- Both `go.sum` files verified single-copy at 0.59.1. `go build`, `go vet`, unit tests green.
- No `go`/`toolchain` directive moved; both modules stay on go 1.25.0.

## Verification gate

No new workflow. `.github/workflows/test.yaml` already runs `go vet` + `go test ./...` on `sandbox-api` and the integration suite on `pull_request` for `sandbox-api/**`, which this diff touches. Retrofitting a dependency-only gate would narrow the repo's own CI.

One fix included: `dependency-verification.yml`'s two job-level conditions matched only the old `cploujoux/devin/dependabot-` prefix. A job whose `if:` is false reports **skipped**, and skipped reads as green — so a future sweep on the current branch name would have looked gated when it was not. Widened to accept both. (That workflow's `paths:` filter is `hub/**`, so it does not fire on this PR either way; the fix is for future runs.)

## Residual risk, stated rather than implied

- **The advisory is not reproduced and the test does not try.** GHSA-vvgj-x9jq-8cj9 is QPACK trailer memory exhaustion, needing a hand-rolled QPACK encoder emitting oversized field lists. Closure rests on the version floor plus the go.sum check. Not worth building a repro for a moderate on an unreachable path.
- The new test covers a handshake and round trip. It does **not** cover malformed/oversized QPACK trailers, HTTP/3 datagrams, 0-RTT, connection migration, or congestion behaviour.
- Validated locally with go 1.26.2 while CI uses go 1.25. CI is the authoritative run.

## Pre-existing local failures, deliberately not touched

Two `src/handler/process` unit tests fail on macOS because sparse-file hole punching is Linux-only and APFS does not release the blocks. The integration suite is also red on this host (MCP session handling, `/proc`-dependent OOM biasing, port-monitor timing, two flaky port/stream tests). Both confirmed identical on untouched `main`, both expected green on the ubuntu runner. A `//go:build linux` guard would make local runs honest — worth a follow-up, but unrelated source does not belong in a dependency PR.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->