### PR TITLE
fix(sandbox-api): keep log streams alive across a process restart

### DIFF
--- a/sandbox-api/src/api/logs_stream_restart_test.go
+++ b/sandbox-api/src/api/logs_stream_restart_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blaxel-ai/sandbox-api/src/handler/process"
+	"github.com/gin-gonic/gin"
+)
+
+// A log stream must survive a restart of the process it follows.
+//
+// The handler used to wait on the per-run Done channel, which a restart closes
+// before installing a fresh one. So the stream ended with 200 and no error the
+// moment the process bounced, while the process came back up and kept producing
+// output nobody received: from the caller's side the process looks alive and
+// silent, with nothing in the logs explaining why.
+func TestLogStreamSurvivesProcessRestart(t *testing.T) {
+	originalLogDir := process.ProcessLogDir
+	process.ProcessLogDir = t.TempDir()
+	t.Cleanup(func() { process.ProcessLogDir = originalLogDir })
+	gin.SetMode(gin.TestMode)
+	server := httptest.NewServer(SetupRouter(true, false))
+	defer server.Close()
+
+	// Fails once, restarts, then prints run2 and stays up.
+	marker := process.ProcessLogDir + "/once"
+	command := "sh -c 'if [ ! -f " + marker + " ]; then touch " + marker +
+		"; echo run1; exit 1; fi; echo run2; sleep 30'"
+	body, err := json.Marshal(map[string]any{
+		"command":          command,
+		"name":             "restarter",
+		"restartOnFailure": true,
+		"maxRestarts":      3,
+	})
+	if err != nil {
+		t.Fatalf("marshalling request: %v", err)
+	}
+	resp, err := http.Post(server.URL+"/process", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("starting process: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("starting process: status %d", resp.StatusCode)
+	}
+
+	streamResp, err := http.Get(server.URL + "/process/restarter/logs/stream")
+	if err != nil {
+		t.Fatalf("opening stream: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	lines := make(chan string, 64)
+	go func() {
+		defer close(lines)
+		scanner := bufio.NewScanner(streamResp.Body)
+		for scanner.Scan() {
+			lines <- scanner.Text()
+		}
+	}()
+
+	// "run2" only exists after the restart, so receiving it proves the stream
+	// outlived the restart rather than ending with the first run.
+	var seen []string
+	deadline := time.After(30 * time.Second)
+	for {
+		select {
+		case line, ok := <-lines:
+			if !ok {
+				t.Fatalf("stream closed before the restarted process produced output; saw: %v", seen)
+			}
+			if strings.Contains(line, "[keepalive]") {
+				continue
+			}
+			seen = append(seen, line)
+			if strings.Contains(line, "run2") {
+				return // the stream carried across the restart
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for post-restart output; saw: %v", seen)
+		}
+	}
+}

--- a/sandbox-api/src/handler/process.go
+++ b/sandbox-api/src/handler/process.go
@@ -537,14 +537,22 @@ func (h *ProcessHandler) HandleGetProcessLogsStream(c *gin.Context) {
 		return
 	}
 
-	// Wait until the process is done or the client disconnects
+	// Wait until the process is done for good, or the client disconnects.
+	//
+	// Waiting on Done here used to end the stream on a restart: a restart closes
+	// the current Done and installs a fresh one, so the handler returned 200
+	// while the process bounced back up and kept producing output nobody
+	// received. Finished is closed once, when there is no restart to come.
 	proc, exists := h.processManager.GetProcessByIdentifier(identifier)
 	if !exists {
 		return
 	}
+	streamStart := time.Now()
 	select {
-	case <-proc.Done:
+	case <-proc.Finished:
+		logStreamEnd(identifier, "process_finished", streamStart, rw)
 	case <-c.Request.Context().Done():
+		logStreamEnd(identifier, "client_disconnected", streamStart, rw)
 		h.RemoveLogWriter(identifier, rw)
 		return
 	}
@@ -562,6 +570,21 @@ func (h *ProcessHandler) HandleGetProcessLogsStream(c *gin.Context) {
 			rw.Write(content)
 		}
 	}
+}
+
+// logStreamEnd records why a log stream ended. Without it a stream that ends
+// because the client hung up is indistinguishable from one that ends because
+// the process finished: both return 200 (the status was fixed when the headers
+// went out, at the first log line) and neither leaves a trace. Three separate
+// customer investigations came down to guessing which of the two happened.
+func logStreamEnd(identifier, reason string, start time.Time, rw *ResponseWriter) {
+	logrus.WithFields(logrus.Fields{
+		"process":    identifier,
+		"reason":     reason,
+		"duration":   time.Since(start).Round(time.Millisecond).String(),
+		"bytes_sent": rw.BytesSent(),
+		"source":     "process_logs_stream",
+	}).Info("Log stream ended")
 }
 
 // HandleStopProcess handles DELETE requests to /process/{identifier}
@@ -652,10 +675,11 @@ func (h *ProcessHandler) HandleGetProcess(c *gin.Context) {
 
 // ResponseWriter is a custom writer for SSE responses that also flushes after each write
 type ResponseWriter struct {
-	gin      *gin.Context
-	closed   bool
-	sentData bool // Track if any data was sent
-	mu       sync.Mutex
+	gin       *gin.Context
+	closed    bool
+	sentData  bool // Track if any data was sent
+	bytesSent int  // Total bytes written to the client, for the stream-end log
+	mu        sync.Mutex
 }
 
 // Write writes data to the buffer and flushes to the client in a safe manner
@@ -685,8 +709,16 @@ func (w *ResponseWriter) Write(data []byte) (int, error) {
 		w.closed = true
 		return 0, err
 	}
+	w.bytesSent += n
 	w.gin.Writer.Flush()
 	return n, nil
+}
+
+// BytesSent reports how much was written to the client so far.
+func (w *ResponseWriter) BytesSent() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.bytesSent
 }
 
 // HasSentData returns true if any data was sent

--- a/sandbox-api/src/handler/process/finished_on_restart_test.go
+++ b/sandbox-api/src/handler/process/finished_on_restart_test.go
@@ -1,0 +1,100 @@
+package process
+
+import (
+	"testing"
+	"time"
+)
+
+// A restart closes the per-run Done channel and installs a fresh one. Anything
+// user-facing that waits on Done therefore sees "the process ended" every time
+// the process merely bounces: the log stream handler returned 200 mid-restart
+// while the process came back up and kept producing output nobody received.
+// Finished must stay open across restarts and close only once, for good.
+func TestFinishedStaysOpenAcrossRestart(t *testing.T) {
+	originalLogDir := ProcessLogDir
+	ProcessLogDir = t.TempDir()
+	t.Cleanup(func() { ProcessLogDir = originalLogDir })
+	pm := NewProcessManager()
+
+	// Fails once, then runs long enough for us to observe the restarted state.
+	cmd := `if [ ! -f "$MARKER" ]; then touch "$MARKER"; echo run1; exit 1; fi; echo run2; sleep 30`
+	proc, err := pm.ExecuteProcess(
+		"sh -c '"+cmd+"'", "", "restarter",
+		map[string]string{"MARKER": ProcessLogDir + "/once"},
+		false, 0, nil, true, 3, false,
+	)
+	if err != nil {
+		t.Fatalf("starting process: %v", err)
+	}
+	firstRunDone := proc.Done
+
+	// The first run's Done closes as soon as that run fails.
+	select {
+	case <-firstRunDone:
+	case <-time.After(15 * time.Second):
+		t.Fatal("first run never signalled Done")
+	}
+
+	// That is exactly the moment the stream handler used to give up. Finished
+	// must not be closed here: the process is coming back.
+	select {
+	case <-proc.Finished:
+		t.Fatal("Finished closed on a restart; a log stream would end while the process runs on")
+	default:
+	}
+
+	// Wait for the restart to land (the manager sleeps 1s before restarting).
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		current, ok := pm.GetProcessByIdentifier("restarter")
+		if ok && current.Status == StatusRunning && current.Done != firstRunDone {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	restarted, ok := pm.GetProcessByIdentifier("restarter")
+	if !ok {
+		t.Fatal("process disappeared after restart")
+	}
+	if restarted.Status != StatusRunning {
+		t.Fatalf("expected the process to be running again, got %q", restarted.Status)
+	}
+	if restarted.Done == firstRunDone {
+		t.Fatal("expected a fresh Done channel for the new run")
+	}
+	select {
+	case <-restarted.Finished:
+		t.Fatal("Finished closed while the restarted process is still running")
+	default:
+	}
+
+	// And it does close once the process is really over.
+	if err := pm.KillProcess("restarter"); err != nil {
+		t.Fatalf("killing process: %v", err)
+	}
+	select {
+	case <-restarted.Finished:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Finished never closed after the process was killed")
+	}
+}
+
+// Without a restart, Finished closes on the single run ending.
+func TestFinishedClosesWithoutRestart(t *testing.T) {
+	originalLogDir := ProcessLogDir
+	ProcessLogDir = t.TempDir()
+	t.Cleanup(func() { ProcessLogDir = originalLogDir })
+	pm := NewProcessManager()
+
+	proc, err := pm.ExecuteProcess("sh -c 'echo hi'", "", "oneshot", nil, false, 0, nil, false, 0, false)
+	if err != nil {
+		t.Fatalf("starting process: %v", err)
+	}
+
+	select {
+	case <-proc.Finished:
+	case <-time.After(15 * time.Second):
+		t.Fatal("Finished never closed for a process that ran once and exited")
+	}
+}

--- a/sandbox-api/src/handler/process/finished_on_restore_test.go
+++ b/sandbox-api/src/handler/process/finished_on_restore_test.go
@@ -1,0 +1,82 @@
+package process
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Processes restored from disk after a sandbox-api restart get their
+// ProcessInfo from a struct literal rather than the constructor. A Finished
+// channel missing there is nil, and a receive on a nil channel blocks forever:
+// the log stream of a restored process would never end server-side, leaving
+// its client on keepalives long after the process was over.
+func TestRestoredProcessHasAUsableFinishedChannel(t *testing.T) {
+	originalLogDir := ProcessLogDir
+	dir := t.TempDir()
+	ProcessLogDir = dir
+	t.Cleanup(func() { ProcessLogDir = originalLogDir })
+
+	stateFile := filepath.Join(dir, "state.json")
+	t.Setenv("SANDBOX_STATE_FILE", stateFile)
+
+	logFile := filepath.Join(dir, "restored.log")
+	for _, f := range []string{logFile,
+		filepath.Join(dir, "restored.stdout.log"),
+		filepath.Join(dir, "restored.stderr.log")} {
+		if err := os.WriteFile(f, []byte("stdout:hi\n"), 0o644); err != nil {
+			t.Fatalf("seeding log file: %v", err)
+		}
+	}
+
+	completed := time.Now().Add(-time.Minute)
+	state := ManagerState{
+		Version: 1,
+		SavedAt: time.Now(),
+		Processes: map[string]ProcessState{
+			"1234": {
+				PID:         "1234",
+				Name:        "restored",
+				Command:     "echo hi",
+				ProcessPid:  999999, // long gone
+				StartedAt:   completed.Add(-time.Minute),
+				CompletedAt: &completed,
+				ExitCode:    0,
+				Status:      StatusCompleted,
+				LogFile:     logFile,
+				StdoutFile:  filepath.Join(dir, "restored.stdout.log"),
+				StderrFile:  filepath.Join(dir, "restored.stderr.log"),
+			},
+		},
+	}
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("encoding state: %v", err)
+	}
+	if err := os.WriteFile(stateFile, encoded, 0o644); err != nil {
+		t.Fatalf("writing state file: %v", err)
+	}
+
+	pm := NewProcessManager()
+	if err := pm.LoadState(); err != nil {
+		t.Fatalf("loading state: %v", err)
+	}
+
+	proc, ok := pm.GetProcessByIdentifier("restored")
+	if !ok {
+		t.Fatal("the process was not restored")
+	}
+	if proc.Finished == nil {
+		t.Fatal("Finished is nil on a restored process: a stream waiting on it would block forever")
+	}
+
+	// It was already over when restored, so a stream attaching to it must be
+	// told so immediately rather than hanging on keepalives.
+	select {
+	case <-proc.Finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Finished never closed for a process restored in a completed state")
+	}
+}

--- a/sandbox-api/src/handler/process/process.go
+++ b/sandbox-api/src/handler/process/process.go
@@ -725,6 +725,14 @@ func (pm *ProcessManager) restartProcess(oldProcess *ProcessInfo, callback func(
 	}
 	cmdArgs = append(cmdArgs, command)
 
+	// Swap in the new run's channels before anything that can fail. The caller
+	// closed the previous Done before calling us, and closes Done again if we
+	// return an error; leaving the old channel in place until after the
+	// working-dir and log-file checks made that second close panic on an
+	// already-closed channel.
+	oldProcess.Done = make(chan struct{})
+	oldProcess.TailDone = make(chan struct{})
+
 	cmd := exec.Command(shell, cmdArgs...)
 
 	if workingDir != "" {
@@ -771,8 +779,6 @@ func (pm *ProcessManager) restartProcess(oldProcess *ProcessInfo, callback func(
 	oldProcess.ExitCode = 0
 	oldProcess.stopTimeout = make(chan struct{})
 	oldProcess.stopTimeoutOnce = sync.Once{}
-	oldProcess.Done = make(chan struct{})
-	oldProcess.TailDone = make(chan struct{})
 
 	// Start the process
 	if err := cmd.Start(); err != nil {

--- a/sandbox-api/src/handler/process/process.go
+++ b/sandbox-api/src/handler/process/process.go
@@ -92,13 +92,20 @@ type ProcessInfo struct {
 	StderrFile       string                  `json:"-"` // Path to stderr log file
 	Done             chan struct{}
 	TailDone         chan struct{} // Closed when tailLogFiles finishes its final reads
-	stdout           *strings.Builder
-	stderr           *strings.Builder
-	logs             *strings.Builder
-	logWriters       []io.Writer
-	logLock          sync.RWMutex
-	stopTimeout      chan struct{} // Channel to signal timeout goroutine to stop
-	stopTimeoutOnce  sync.Once    // Protects stopTimeout channel from double-close
+	// Finished is closed once the process is over for good, with no restart to
+	// come. Done is per-run: a restart closes it and installs a fresh one, so a
+	// consumer waiting on Done sees "finished" every time the process merely
+	// bounces. Anything user-facing that means "this process is over" must wait
+	// on Finished instead.
+	Finished        chan struct{}
+	finishOnce      sync.Once
+	stdout          *strings.Builder
+	stderr          *strings.Builder
+	logs            *strings.Builder
+	logWriters      []io.Writer
+	logLock         sync.RWMutex
+	stopTimeout     chan struct{} // Channel to signal timeout goroutine to stop
+	stopTimeoutOnce sync.Once     // Protects stopTimeout channel from double-close
 }
 
 // ProcessLogDir is the directory where process logs are stored
@@ -121,6 +128,12 @@ func init() {
 
 // shouldRestart reports whether a failed process is eligible for another
 // restart attempt. A negative MaxRestarts means unlimited restarts.
+// markFinished closes Finished exactly once. Safe to call from every terminal
+// path, including ones that may overlap.
+func (p *ProcessInfo) markFinished() {
+	p.finishOnce.Do(func() { close(p.Finished) })
+}
+
 func shouldRestart(p *ProcessInfo) bool {
 	return p.Status == StatusFailed && p.RestartOnFailure &&
 		(p.MaxRestarts < 0 || p.RestartCount < p.MaxRestarts)
@@ -291,6 +304,7 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 		StderrFile:       stderrPath,
 		Done:             make(chan struct{}),
 		TailDone:         make(chan struct{}),
+		Finished:         make(chan struct{}),
 		stdout:           stdout,
 		stderr:           stderr,
 		logs:             logs,
@@ -479,6 +493,7 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 				process.logWriters = nil
 				process.logLock.Unlock()
 
+				process.markFinished()
 				callback(process)
 			}
 			// If restart succeeds, the callback will be called when that process completes
@@ -509,6 +524,7 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 			process.logWriters = nil
 			process.logLock.Unlock()
 
+			process.markFinished()
 			callback(process)
 		}
 	}()
@@ -858,6 +874,7 @@ func (pm *ProcessManager) restartProcess(oldProcess *ProcessInfo, callback func(
 				oldProcess.logWriters = nil
 				oldProcess.logLock.Unlock()
 
+				oldProcess.markFinished()
 				callback(oldProcess)
 			}
 			// If restart succeeds, the callback will be called when that process completes
@@ -888,6 +905,7 @@ func (pm *ProcessManager) restartProcess(oldProcess *ProcessInfo, callback func(
 			oldProcess.logWriters = nil
 			oldProcess.logLock.Unlock()
 
+			oldProcess.markFinished()
 			callback(oldProcess)
 		}
 	}()
@@ -1196,22 +1214,32 @@ func (pm *ProcessManager) StreamProcessOutput(identifier string, w io.Writer) er
 	process.logWriters = append(process.logWriters, w)
 	process.logLock.Unlock()
 
-	// Start keepalive goroutine to prevent connection timeout
+	// Keep the connection warm for as long as this writer is attached.
+	//
+	// Tied to Finished rather than to a "status is running" check: during a
+	// restart the status is briefly Failed, and stopping on that left the
+	// stream with no traffic at all for the rest of its life. Idle connections
+	// are reaped upstream after five minutes, so a quiet process would then
+	// lose its stream for no reason. A failing write means the client is gone.
 	go func() {
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			process, exists = pm.GetProcessByIdentifier(identifier)
-			// Check if process is still running
-			if !exists || process.Status != StatusRunning {
+		keepaliveMsg := []byte("[keepalive]\n")
+		for {
+			select {
+			case <-process.Finished:
 				return
-			}
-			// Send keepalive message only to this specific writer
-			keepaliveMsg := []byte("[keepalive]\n")
-			_, _ = w.Write(keepaliveMsg)
-			if f, ok := w.(interface{ Flush() }); ok {
-				f.Flush()
+			case <-ticker.C:
+				if _, stillTracked := pm.GetProcessByIdentifier(identifier); !stillTracked {
+					return
+				}
+				if _, writeErr := w.Write(keepaliveMsg); writeErr != nil {
+					return
+				}
+				if f, ok := w.(interface{ Flush() }); ok {
+					f.Flush()
+				}
 			}
 		}
 	}()

--- a/sandbox-api/src/handler/process/restart_failure_test.go
+++ b/sandbox-api/src/handler/process/restart_failure_test.go
@@ -1,0 +1,103 @@
+package process
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// A restart that fails before it gets going must not take the API down.
+//
+// The caller closes Done before calling restartProcess and closes it again if
+// restartProcess returns an error. While the channel was only swapped after the
+// working-directory and log-file checks, an early failure left the old, already
+// closed channel in place, and that second close panicked on a closed channel,
+// killing the whole API rather than one process.
+func TestFailedRestartLeavesAFreshDoneChannel(t *testing.T) {
+	originalLogDir := ProcessLogDir
+	dir := t.TempDir()
+	ProcessLogDir = dir
+	t.Cleanup(func() { ProcessLogDir = originalLogDir })
+
+	pm := NewProcessManager()
+	closedDone := make(chan struct{})
+	close(closedDone) // the caller has already signalled the previous run's end
+	closedTail := make(chan struct{})
+	close(closedTail)
+
+	proc := &ProcessInfo{
+		PID:        "1",
+		Name:       "early-fail",
+		Command:    "echo hi",
+		WorkingDir: filepath.Join(dir, "does-not-exist"),
+		StdoutFile: filepath.Join(dir, "p.stdout.log"),
+		StderrFile: filepath.Join(dir, "p.stderr.log"),
+		LogFile:    filepath.Join(dir, "p.log"),
+		Done:       closedDone,
+		TailDone:   closedTail,
+		Finished:   make(chan struct{}),
+		stdout:     newLogBuffer(),
+		stderr:     newLogBuffer(),
+		logs:       newLogBuffer(),
+	}
+
+	_, err := pm.restartProcess(proc, func(*ProcessInfo) {})
+	if err == nil {
+		t.Fatal("expected the restart to fail on a missing working directory")
+	}
+
+	if proc.Done == closedDone {
+		t.Fatal("Done still points at the closed channel: the caller's second close would panic")
+	}
+
+	// What the caller does next, and what used to bring the API down.
+	var panicked any
+	func() {
+		defer func() { panicked = recover() }()
+		close(proc.Done)
+	}()
+	if panicked != nil {
+		t.Fatalf("closing Done after a failed restart panicked: %v", panicked)
+	}
+}
+
+// restartProcess is called from the manager's own goroutine, so a panic there
+// is fatal to the API. Guard the concurrent shape too.
+func TestFailedRestartIsSafeFromSeveralGoroutines(t *testing.T) {
+	originalLogDir := ProcessLogDir
+	dir := t.TempDir()
+	ProcessLogDir = dir
+	t.Cleanup(func() { ProcessLogDir = originalLogDir })
+
+	pm := NewProcessManager()
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			proc := &ProcessInfo{
+				PID:        "1",
+				Name:       "early-fail",
+				Command:    "echo hi",
+				WorkingDir: filepath.Join(dir, "does-not-exist"),
+				StdoutFile: filepath.Join(dir, "p.stdout.log"),
+				StderrFile: filepath.Join(dir, "p.stderr.log"),
+				LogFile:    filepath.Join(dir, "p.log"),
+				Done:       make(chan struct{}),
+				TailDone:   make(chan struct{}),
+				Finished:   make(chan struct{}),
+				stdout:     newLogBuffer(),
+				stderr:     newLogBuffer(),
+				logs:       newLogBuffer(),
+			}
+			if _, err := pm.restartProcess(proc, func(*ProcessInfo) {}); err == nil {
+				t.Error("expected the restart to fail")
+				return
+			}
+			close(proc.Done) // must not panic
+			proc.markFinished()
+			proc.markFinished() // idempotent
+		}()
+	}
+	wg.Wait()
+}

--- a/sandbox-api/src/handler/process/state.go
+++ b/sandbox-api/src/handler/process/state.go
@@ -235,6 +235,7 @@ func (pm *ProcessManager) LoadState() error {
 			Env:              procState.Env,
 			Done:             make(chan struct{}),
 			TailDone:         make(chan struct{}),
+			Finished:         make(chan struct{}),
 			stdout:           newLogBuffer(),
 			stderr:           newLogBuffer(),
 			logs:             newLogBuffer(),
@@ -291,6 +292,7 @@ func (pm *ProcessManager) LoadState() error {
 				proc.ExitCode = -1
 				close(proc.Done)
 				close(proc.TailDone)
+				proc.markFinished()
 				deadCount++
 				pm.processes[pid] = proc
 				continue
@@ -334,6 +336,7 @@ func (pm *ProcessManager) LoadState() error {
 			// Close the Done and TailDone channels since process is no longer running
 			close(proc.Done)
 			close(proc.TailDone)
+			proc.markFinished()
 
 			logrus.WithFields(logrus.Fields{
 				"pid":     proc.PID,
@@ -345,6 +348,7 @@ func (pm *ProcessManager) LoadState() error {
 			if proc.CompletedAt != nil {
 				close(proc.Done)
 				close(proc.TailDone)
+				proc.markFinished()
 			}
 		}
 
@@ -625,6 +629,7 @@ func (pm *ProcessManager) monitorAdoptedProcess(proc *ProcessInfo) {
 				// Signal that the process is done
 				close(proc.Done)
 				close(proc.TailDone)
+				proc.markFinished()
 
 				logrus.WithFields(logrus.Fields{
 					"pid":         proc.PID,


### PR DESCRIPTION
## What

Log streams no longer end when the process they follow restarts, and we now log why every stream ended.

## Why

The stream handler waited on `ProcessInfo.Done`. That channel is per-run: a restart closes it and installs a fresh one. So when a process with `restartOnFailure` bounced, the handler returned, the stream ended with **200 and no error**, and the process came back up and kept producing output nobody received.

From the caller's side the process looks alive, healthy, and silent. Nothing in the logs said otherwise.

Reproduced: stream ends at 20.1s on the restart, process status `running`, and the post-restart output (`run2 tick 1,2,3`) never reaches the client.

## Changes

**1. `Finished`, separate from `Done`.** `Done` keeps its internal role of telling `tailLogFiles` a run ended. `Finished` closes exactly once, when the process is over for good, and that is what the stream handler waits on.

**2. Keepalives survive restarts too.** The keepalive goroutine stopped as soon as the status was not `running`, which a restart briefly makes true, so it exited permanently. With streams now surviving restarts, a quiet process would have been left with no traffic and reaped by the upstream 5-minute idle backstop. It now runs until `Finished`, and stops when a write fails, which also closes a goroutine leak on client disconnect.

**3. Log why streams end.** A stream ending on client disconnect and one ending on the process finishing both return 200 (the status is fixed when headers go out, at the first log line), and neither left a trace. Three customer investigations came down to guessing which happened. Now: reason, duration, bytes sent.

## Tests

- `src/api/logs_stream_restart_test.go` — drives the real HTTP handler: opens a stream, lets the process crash and restart, asserts post-restart output still arrives. **Fails on main** with `stream closed before the restarted process produced output`.
- `src/handler/process/finished_on_restart_test.go` — `Finished` stays open across a restart, closes once the process is really gone, and closes for a plain one-shot process.

Full suite green except 5 pre-existing failures in `src/handler/process` that need `/var/log/sandbox-api` and fail on macOS on `main` too.

## Context

Found while investigating customer reports of log streams ending early while the process kept running. This is one real cause of that symptom; it is **not** confirmed as the cause of the reported incidents (their logs show no restart). Worth fixing regardless.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->