### PR TITLE
fix(sandbox-api): prefix log lines, not read chunks

### DIFF
--- a/sandbox-api/integration-tests/tests/process/long_line_stream_test.go
+++ b/sandbox-api/integration-tests/tests/process/long_line_stream_test.go
@@ -1,0 +1,138 @@
+package tests
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blaxel-ai/sandbox-api/integration_tests/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// uniqueProcessName keeps repeated runs against a long-lived sandbox-api from
+// colliding on a name that is still registered.
+func uniqueProcessName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+// payloadSize is comfortably past the 4096-byte read buffer, so the line spans
+// several reads however the tailer happens to slice it.
+const payloadSize = 9000
+
+// startLongLineProcess runs a command emitting one JSON line larger than the
+// read buffer, and returns the process name.
+func startLongLineProcess(t *testing.T, name string, settleBeforeStream time.Duration) string {
+	t.Helper()
+	command := fmt.Sprintf(
+		`sh -c 'payload=$(head -c %d /dev/zero | tr "\0" "x"); echo "{\"type\":\"tool\",\"output\":\"$payload\"}"; sleep 10'`,
+		payloadSize,
+	)
+	resp, err := common.MakeRequest(http.MethodPost, "/process", map[string]interface{}{
+		"command": command,
+		"name":    name,
+	})
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Controls whether the line is replayed from the log file or arrives live.
+	time.Sleep(settleBeforeStream)
+	return name
+}
+
+// readTaggedLines collects stream lines for a while, dropping keepalives.
+func readTaggedLines(t *testing.T, processName string, window time.Duration) []string {
+	t.Helper()
+	streamResp, err := common.MakeRequestWithTimeout(
+		http.MethodGet, "/process/"+processName+"/logs/stream", nil, window+5*time.Second)
+	require.NoError(t, err)
+	defer streamResp.Body.Close()
+	require.Equal(t, http.StatusOK, streamResp.StatusCode)
+
+	linesCh := make(chan string, 32)
+	go func() {
+		reader := bufio.NewReader(streamResp.Body)
+		for {
+			line, err := reader.ReadString('\n')
+			if line != "" {
+				linesCh <- line
+			}
+			if err != nil {
+				close(linesCh)
+				return
+			}
+		}
+	}()
+
+	var received []string
+	deadline := time.After(window)
+	for {
+		select {
+		case line, ok := <-linesCh:
+			if !ok {
+				return received
+			}
+			if strings.HasPrefix(line, "[keepalive]") {
+				continue
+			}
+			received = append(received, line)
+		case <-deadline:
+			return received
+		}
+	}
+}
+
+// assertLineSurvived checks the payload reached the client whole: tagged once,
+// at the start, and still valid JSON.
+func assertLineSurvived(t *testing.T, lines []string) {
+	t.Helper()
+	var payload string
+	for _, line := range lines {
+		if strings.Contains(line, `"type":"tool"`) {
+			payload = line
+			break
+		}
+	}
+	require.NotEmpty(t, payload, "the long line never arrived; got %d lines", len(lines))
+
+	body := strings.TrimPrefix(payload, "stdout:")
+	// Reported by offset rather than by dumping the payload: a failure prints a
+	// 9KB line otherwise, and the offset is the diagnosis (it lands on a
+	// multiple of the read buffer).
+	if idx := strings.Index(body, "stdout:"); idx != -1 {
+		t.Fatalf("stream tag spliced into the line at byte %d of %d: "+
+			"a read boundary was treated as a line boundary", idx, len(body))
+	}
+
+	var parsed struct {
+		Type   string `json:"type"`
+		Output string `json:"output"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimRight(body, "\n")), &parsed),
+		"the line no longer parses as JSON")
+	assert.Equal(t, payloadSize, len(parsed.Output), "payload truncated in transit")
+}
+
+// A log line longer than the read buffer must reach a client intact.
+//
+// The stream tags output with "stdout:" / "stderr:". Tagging each read rather
+// than each line spliced the tag into the middle of any line past the buffer,
+// so a consumer parsing its own output failed on valid data, and the bigger the
+// output the more certain the failure.
+func TestLongLineArrivesIntactLive(t *testing.T) {
+	// Stream attached first: the line arrives through the live path.
+	name := startLongLineProcess(t, uniqueProcessName("longline-live"), 0)
+	assertLineSurvived(t, readTaggedLines(t, name, 3*time.Second))
+}
+
+func TestLongLineArrivesIntactFromBacklog(t *testing.T) {
+	// Stream attached after the line was written: it is replayed from the
+	// combined log file, which was corrupted the same way.
+	name := startLongLineProcess(t, uniqueProcessName("longline-backlog"), 2*time.Second)
+	assertLineSurvived(t, readTaggedLines(t, name, 3*time.Second))
+}

--- a/sandbox-api/src/api/logs_stream_long_line_test.go
+++ b/sandbox-api/src/api/logs_stream_long_line_test.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blaxel-ai/sandbox-api/src/handler/process"
+	"github.com/gin-gonic/gin"
+)
+
+// A log line longer than the read buffer must reach the client intact.
+//
+// The stream used to tag each 4096-byte read rather than each line, so a long
+// line came out with "stdout:" spliced into the middle of it. Any consumer
+// parsing the line then failed on perfectly valid application output, and the
+// bigger the output the more certain the failure.
+func TestLogStreamKeepsLongLinesIntact(t *testing.T) {
+	originalLogDir := process.ProcessLogDir
+	process.ProcessLogDir = t.TempDir()
+	t.Cleanup(func() { process.ProcessLogDir = originalLogDir })
+	gin.SetMode(gin.TestMode)
+	server := httptest.NewServer(SetupRouter(true, false))
+	defer server.Close()
+
+	// One JSON line well past the 4096-byte read buffer, like a large tool result.
+	const payloadSize = 9000
+	command := `sh -c 'payload=$(head -c ` + itoa(payloadSize) + ` /dev/zero | tr "\0" "x"); ` +
+		`echo "{\"type\":\"tool\",\"output\":\"$payload\"}"; sleep 10'`
+	body, err := json.Marshal(map[string]any{"command": command, "name": "longline"})
+	if err != nil {
+		t.Fatalf("marshalling request: %v", err)
+	}
+	resp, err := http.Post(server.URL+"/process", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("starting process: %v", err)
+	}
+	resp.Body.Close()
+
+	streamResp, err := http.Get(server.URL + "/process/longline/logs/stream")
+	if err != nil {
+		t.Fatalf("opening stream: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	lines := make(chan string, 16)
+	go func() {
+		defer close(lines)
+		scanner := bufio.NewScanner(streamResp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			lines <- scanner.Text()
+		}
+	}()
+
+	deadline := time.After(30 * time.Second)
+	for {
+		select {
+		case line, ok := <-lines:
+			if !ok {
+				t.Fatal("stream ended before the long line arrived")
+			}
+			if !strings.Contains(line, `"type":"tool"`) {
+				continue
+			}
+			payload := strings.TrimPrefix(line, "stdout:")
+
+			// The tag belongs at the start, and nowhere else.
+			if idx := strings.Index(payload, "stdout:"); idx != -1 {
+				t.Fatalf("stream tag spliced into the line at byte %d", idx)
+			}
+			var parsed struct {
+				Type   string `json:"type"`
+				Output string `json:"output"`
+			}
+			if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+				t.Fatalf("line no longer parses as JSON: %v", err)
+			}
+			if len(parsed.Output) != payloadSize {
+				t.Fatalf("payload truncated: got %d bytes, want %d", len(parsed.Output), payloadSize)
+			}
+			return
+		case <-deadline:
+			t.Fatal("timed out waiting for the long line")
+		}
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/sandbox-api/src/handler/process/prefix_lines_test.go
+++ b/sandbox-api/src/handler/process/prefix_lines_test.go
@@ -1,0 +1,99 @@
+package process
+
+import (
+	"strings"
+	"testing"
+)
+
+// The read buffer is a fixed-size window, not a line. Prefixing the chunk
+// rather than its line starts spliced "stdout:" into the middle of any line
+// longer than the buffer, which corrupted it for every consumer: a >4KB JSON
+// line arrived with the tag at byte 4096 and stopped parsing.
+func TestPrefixLines(t *testing.T) {
+	tests := []struct {
+		name            string
+		chunks          []string
+		wantOut         []string
+		wantReassembled string
+	}{
+		{
+			name:            "whole lines are each tagged",
+			chunks:          []string{"a\nb\n"},
+			wantOut:         []string{"stdout:a\nstdout:b\n"},
+			wantReassembled: "stdout:a\nstdout:b\n",
+		},
+		{
+			name:            "a line split across chunks is tagged once",
+			chunks:          []string{"{\"big\":\"aaa", "bbb", "ccc\"}\n"},
+			wantOut:         []string{"stdout:{\"big\":\"aaa", "bbb", "ccc\"}\n"},
+			wantReassembled: "stdout:{\"big\":\"aaabbbccc\"}\n",
+		},
+		{
+			name:            "a chunk ending exactly on a newline starts the next one fresh",
+			chunks:          []string{"first\n", "second\n"},
+			wantOut:         []string{"stdout:first\n", "stdout:second\n"},
+			wantReassembled: "stdout:first\nstdout:second\n",
+		},
+		{
+			name:            "trailing partial line resumes untagged",
+			chunks:          []string{"done\npart", "ial\n"},
+			wantOut:         []string{"stdout:done\nstdout:part", "ial\n"},
+			wantReassembled: "stdout:done\nstdout:partial\n",
+		},
+		{
+			name:            "empty chunk changes nothing",
+			chunks:          []string{"x\n", "", "y\n"},
+			wantOut:         []string{"stdout:x\n", "", "stdout:y\n"},
+			wantReassembled: "stdout:x\nstdout:y\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			atLineStart := true
+			var got []string
+			var all strings.Builder
+			for _, chunk := range tc.chunks {
+				out, next := prefixLines("stdout", []byte(chunk), atLineStart)
+				atLineStart = next
+				got = append(got, string(out))
+				all.Write(out)
+			}
+			for i := range tc.wantOut {
+				if got[i] != tc.wantOut[i] {
+					t.Errorf("chunk %d: got %q, want %q", i, got[i], tc.wantOut[i])
+				}
+			}
+			if all.String() != tc.wantReassembled {
+				t.Errorf("reassembled: got %q, want %q", all.String(), tc.wantReassembled)
+			}
+		})
+	}
+}
+
+// The regression in its original shape: one line longer than the read buffer.
+func TestPrefixLinesLeavesLongLineIntact(t *testing.T) {
+	const bufSize = 4096
+	payload := strings.Repeat("x", 9000)
+	line := `{"type":"tool","output":"` + payload + `"}` + "\n"
+
+	atLineStart := true
+	var wire strings.Builder
+	for i := 0; i < len(line); i += bufSize {
+		end := i + bufSize
+		if end > len(line) {
+			end = len(line)
+		}
+		out, next := prefixLines("stdout", []byte(line[i:end]), atLineStart)
+		atLineStart = next
+		wire.Write(out)
+	}
+
+	got := wire.String()
+	if strings.Count(got, "stdout:") != 1 {
+		t.Fatalf("expected exactly one tag, got %d", strings.Count(got, "stdout:"))
+	}
+	if body := strings.TrimPrefix(got, "stdout:"); body != line {
+		t.Errorf("line was altered in transit:\n got %.80q...\nwant %.80q...", body, line)
+	}
+}

--- a/sandbox-api/src/handler/process/process.go
+++ b/sandbox-api/src/handler/process/process.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"math/rand"
@@ -31,19 +32,53 @@ type JSONStreamWriter interface {
 	IsJSONStreamWriter() bool
 }
 
-// writeToLogWriter sends data to a log writer, using JSON format if supported
-func writeToLogWriter(w io.Writer, eventType string, data []byte) {
+// prefixLines tags every line start in data with "stdout:" / "stderr:" and
+// reports whether data ended on a line boundary.
+//
+// The caller reads into a fixed-size buffer, so a chunk is a window, not a
+// line: a long line spans several chunks. Prefixing the chunk itself put the
+// tag in the middle of such a line, which corrupted it for every consumer
+// (a >4KB JSON line came out with "stdout:" spliced in at byte 4096 and no
+// longer parsed). atLineStart carries that state across chunks so a
+// continuation resumes untagged.
+func prefixLines(eventType string, data []byte, atLineStart bool) (out []byte, endsAtLineStart bool) {
+	prefix := []byte(eventType + ":")
+	out = make([]byte, 0, len(data)+len(prefix))
+	for len(data) > 0 {
+		if atLineStart {
+			out = append(out, prefix...)
+		}
+		idx := bytes.IndexByte(data, '\n')
+		if idx < 0 {
+			// Chunk ended mid-line; the next one continues it.
+			return append(out, data...), false
+		}
+		out = append(out, data[:idx+1]...)
+		data = data[idx+1:]
+		atLineStart = true
+	}
+	return out, atLineStart
+}
+
+// writeToLogWriter sends one chunk to a log writer. raw is the unprefixed
+// bytes (JSON writers carry the stream in the event type); prefixed is the
+// same bytes tagged at line starts, for plain text writers.
+func writeToLogWriter(w io.Writer, eventType string, raw, prefixed []byte) {
 	if jw, ok := w.(JSONStreamWriter); ok {
 		// JSON writer - send structured event
-		jw.WriteEvent(eventType, string(data))
+		jw.WriteEvent(eventType, string(raw))
 	} else {
-		// Regular writer - send prefixed text (stdout: or stderr:)
-		prefixed := append([]byte(eventType+":"), data...)
 		_, _ = w.Write(prefixed)
 	}
 	if f, ok := w.(interface{ Flush() }); ok {
 		f.Flush()
 	}
+}
+
+// writeLineToLogWriter sends a single whole line, which is always a line start.
+func writeLineToLogWriter(w io.Writer, eventType string, line []byte) {
+	prefixed, _ := prefixLines(eventType, line, true)
+	writeToLogWriter(w, eventType, line, prefixed)
 }
 
 // Define process status constants
@@ -96,9 +131,13 @@ type ProcessInfo struct {
 	stderr           *strings.Builder
 	logs             *strings.Builder
 	logWriters       []io.Writer
-	logLock          sync.RWMutex
-	stopTimeout      chan struct{} // Channel to signal timeout goroutine to stop
-	stopTimeoutOnce  sync.Once    // Protects stopTimeout channel from double-close
+	// Whether the next byte of each stream begins a new line, tracked across
+	// reads so a line split over several chunks is tagged only once.
+	stdoutAtLineStart bool
+	stderrAtLineStart bool
+	logLock           sync.RWMutex
+	stopTimeout       chan struct{} // Channel to signal timeout goroutine to stop
+	stopTimeoutOnce   sync.Once     // Protects stopTimeout channel from double-close
 }
 
 // ProcessLogDir is the directory where process logs are stored
@@ -274,28 +313,30 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 	}
 
 	process := &ProcessInfo{
-		Name:             name,
-		Command:          command,
-		StartedAt:        time.Now(),
-		CompletedAt:      nil,
-		Status:           StatusRunning,
-		WorkingDir:       workingDir,
-		Env:              env,
-		RestartOnFailure: restartOnFailure,
-		MaxRestarts:      maxRestarts,
-		RestartCount:     0,
-		KeepAlive:        keepAlive,
-		Timeout:          timeout,
-		LogFile:          combinedPath,
-		StdoutFile:       stdoutPath,
-		StderrFile:       stderrPath,
-		Done:             make(chan struct{}),
-		TailDone:         make(chan struct{}),
-		stdout:           stdout,
-		stderr:           stderr,
-		logs:             logs,
-		logWriters:       make([]io.Writer, 0),
-		stopTimeout:      make(chan struct{}),
+		Name:              name,
+		Command:           command,
+		StartedAt:         time.Now(),
+		CompletedAt:       nil,
+		Status:            StatusRunning,
+		WorkingDir:        workingDir,
+		Env:               env,
+		RestartOnFailure:  restartOnFailure,
+		MaxRestarts:       maxRestarts,
+		RestartCount:      0,
+		KeepAlive:         keepAlive,
+		Timeout:           timeout,
+		LogFile:           combinedPath,
+		StdoutFile:        stdoutPath,
+		StderrFile:        stderrPath,
+		Done:              make(chan struct{}),
+		TailDone:          make(chan struct{}),
+		stdoutAtLineStart: true,
+		stderrAtLineStart: true,
+		stdout:            stdout,
+		stderr:            stderr,
+		logs:              logs,
+		logWriters:        make([]io.Writer, 0),
+		stopTimeout:       make(chan struct{}),
 	}
 
 	// Redirect stdout/stderr directly to files
@@ -580,14 +621,21 @@ func (pm *ProcessManager) readAndBroadcast(file *os.File, buf []byte, proc *Proc
 			proc.stderr.Write(data)
 		}
 		proc.logs.Write(data)
+		// Tag line starts once, then hand the same bytes to the combined log
+		// file and to every writer, so the file and the live stream agree.
+		atLineStart := proc.stdoutAtLineStart
+		if streamType == "stderr" {
+			atLineStart = proc.stderrAtLineStart
+		}
+		prefixed, endsAtLineStart := prefixLines(streamType, data, atLineStart)
+		if streamType == "stderr" {
+			proc.stderrAtLineStart = endsAtLineStart
+		} else {
+			proc.stdoutAtLineStart = endsAtLineStart
+		}
 		// Write prefixed content to combined log file (preserves interleaved order)
 		if combinedFile != nil {
-			lines := strings.SplitAfter(string(data), "\n")
-			for _, line := range lines {
-				if line != "" {
-					combinedFile.WriteString(streamType + ":" + line)
-				}
-			}
+			combinedFile.Write(prefixed)
 		}
 		// Export process logs to stdout for telemetry collection.
 		// Uses structured log attributes so the telemetry collector can
@@ -615,7 +663,7 @@ func (pm *ProcessManager) readAndBroadcast(file *os.File, buf []byte, proc *Proc
 		}
 		// Send to log writers for streaming
 		for _, w := range proc.logWriters {
-			writeToLogWriter(w, streamType, data)
+			writeToLogWriter(w, streamType, data, prefixed)
 		}
 		proc.logLock.Unlock()
 	}
@@ -697,6 +745,12 @@ func (pm *ProcessManager) restartProcess(oldProcess *ProcessInfo, callback func(
 	oldProcess.stopTimeoutOnce = sync.Once{}
 	oldProcess.Done = make(chan struct{})
 	oldProcess.TailDone = make(chan struct{})
+	// Fresh run, fresh line state: a previous run that died mid-line must not
+	// leave the next one's first line untagged.
+	oldProcess.logLock.Lock()
+	oldProcess.stdoutAtLineStart = true
+	oldProcess.stderrAtLineStart = true
+	oldProcess.logLock.Unlock()
 
 	// Start the process
 	if err := cmd.Start(); err != nil {
@@ -1180,12 +1234,12 @@ func (pm *ProcessManager) StreamProcessOutput(identifier string, w io.Writer) er
 			lines := strings.Split(string(content), "\n")
 			for _, line := range lines {
 				if strings.HasPrefix(line, "stdout:") {
-					writeToLogWriter(w, "stdout", []byte(strings.TrimPrefix(line, "stdout:")+"\n"))
+					writeLineToLogWriter(w, "stdout", []byte(strings.TrimPrefix(line, "stdout:")+"\n"))
 				} else if strings.HasPrefix(line, "stderr:") {
-					writeToLogWriter(w, "stderr", []byte(strings.TrimPrefix(line, "stderr:")+"\n"))
+					writeLineToLogWriter(w, "stderr", []byte(strings.TrimPrefix(line, "stderr:")+"\n"))
 				} else if line != "" {
 					// Fallback for unprefixed lines (shouldn't happen, but handle gracefully)
-					writeToLogWriter(w, "stdout", []byte(line+"\n"))
+					writeLineToLogWriter(w, "stdout", []byte(line+"\n"))
 				}
 			}
 		}


### PR DESCRIPTION
## What

Any log line longer than 4096 bytes was corrupted in transit. This is the root cause of the customer reports of log streams dying while the process kept running.

## The bug

The log stream tags output with `stdout:` / `stderr:`. It applied the tag once per **read**, and a read is a fixed 4096-byte window, not a line:

```go
prefixed := append([]byte(eventType+":"), data...)   // data = buf[:n], 4096 bytes
```

So a line longer than the buffer came out with the tag spliced into its middle:

```
{"type":"tool","output":"xxx...xxxstdout:xxx..."}
                                  ^ byte 4096
```

Measured against a real sandbox, a 9KB JSON line arrives with `stdout:` at index 4096 and no longer parses.

The same splice went into the combined log file, so the backfill a client receives on reconnect was corrupted the same way.

## Why it looked like a transport problem

A consumer parsing NDJSON hits invalid JSON on perfectly valid application output. If its parser treats that as fatal, it tears down its read loop and closes the connection, and from our side the gateway logs a client-side disconnect. The process is untouched and keeps running, so the report reads as "the stream died for no reason while the process was healthy".

It also explains why it worked most of the time: **only lines crossing a 4KB boundary are affected**, which is why the same workload streams fine for 13 minutes and then dies at an arbitrary moment. The customer's three incidents ended at 102s, 117s and 283s — never the same duration, which ruled out every timeout.

## The fix

Track, per stream, whether the next byte starts a line, and tag only real line starts. A line spanning several reads is tagged once, at its start; continuation chunks pass through untouched. Restarts reset the state.

This also fixes the milder half of the same bug, which callers had already hit and worked around: when a read boundary landed on a newline, every following line in that chunk arrived unattributed, so consumers listening on the stdout/stderr callbacks lost all but the first line of a burst (one customer measured 19 of 20).

The wire format is shared, so this covers the Python and Go SDKs too.

## Tests

- `src/api/logs_stream_long_line_test.go` — drives the real HTTP handler with a 9KB line and asserts it arrives intact and parses. **Fails on main** with `stream tag spliced into the line at byte 4096`.
- `src/handler/process/prefix_lines_test.go` — chunk-boundary cases: split mid-line, split on a newline, trailing partial line, empty chunk, and one line longer than the buffer reassembling byte-for-byte.

Full suite green except 5 pre-existing failures in `src/handler/process` that need `/var/log/sandbox-api` and fail on `main` on macOS too.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->