### PR TITLE
Make named process execution idempotent

### DIFF
--- a/sandbox-api/src/handler/process.go
+++ b/sandbox-api/src/handler/process.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 
-	"github.com/blaxel-ai/sandbox-api/src/handler/constants"
 	"github.com/blaxel-ai/sandbox-api/src/handler/process"
 	"github.com/blaxel-ai/sandbox-api/src/lib"
 	"github.com/blaxel-ai/sandbox-api/src/lib/audit"
@@ -109,6 +108,11 @@ func (h *ProcessHandler) ExecuteProcess(command string, workingDir string, name 
 	if processInfo.CompletedAt != nil {
 		completedAt = processInfo.CompletedAt.Format("Mon, 02 Jan 2006 15:04:05 GMT")
 	}
+	logs, stdout, stderr := processInfo.Logs, processInfo.Stdout, processInfo.Stderr
+	if waitForCompletion && err == nil {
+		output := processInfo.Output()
+		logs, stdout, stderr = &output.Logs, &output.Stdout, &output.Stderr
+	}
 
 	// Return the process response even if there's an error (e.g., timeout)
 	// This allows callers to access process info for still-running processes
@@ -121,9 +125,9 @@ func (h *ProcessHandler) ExecuteProcess(command string, workingDir string, name 
 		CompletedAt:      &completedAt,
 		ExitCode:         processInfo.ExitCode,
 		WorkingDir:       processInfo.WorkingDir,
-		Logs:             processInfo.Logs,
-		Stdout:           processInfo.Stdout,
-		Stderr:           processInfo.Stderr,
+		Logs:             logs,
+		Stdout:           stdout,
+		Stderr:           stderr,
 		RestartOnFailure: processInfo.RestartOnFailure,
 		MaxRestarts:      processInfo.MaxRestarts,
 		RestartCount:     processInfo.RestartCount,
@@ -300,15 +304,6 @@ func (h *ProcessHandler) HandleExecuteCommand(c *gin.Context) {
 		req.WorkingDir = formattedWorkingDir
 	}
 
-	// If a name is provided, check if a process with that name already exists
-	if req.Name != "" {
-		alreadyExists, err := h.GetProcess(req.Name)
-		if err == nil && alreadyExists.Status == string(constants.ProcessStatusRunning) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("process with name '%s' already exists and is running", req.Name)})
-			return
-		}
-	}
-
 	audit.LogEvent(c, "process_exec", logrus.Fields{
 		"command":     req.Command,
 		"working-dir": req.WorkingDir,
@@ -355,15 +350,6 @@ func (h *ProcessHandler) handleExecuteCommandStream(c *gin.Context) {
 			return
 		}
 		req.WorkingDir = formattedWorkingDir
-	}
-
-	// If a name is provided, check if a process with that name already exists
-	if req.Name != "" {
-		alreadyExists, err := h.GetProcess(req.Name)
-		if err == nil && alreadyExists.Status == string(constants.ProcessStatusRunning) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("process with name '%s' already exists and is running", req.Name)})
-			return
-		}
 	}
 
 	audit.LogEvent(c, "process_exec_stream", logrus.Fields{

--- a/sandbox-api/src/handler/process/process.go
+++ b/sandbox-api/src/handler/process/process.go
@@ -229,6 +229,7 @@ func (pm *ProcessManager) leaveStopped(proc *ProcessInfo, callback func(*Process
 	proc.logLock.Lock()
 	proc.logWriters = nil
 	proc.logLock.Unlock()
+	proc.markFinished()
 
 	if callback != nil {
 		callback(proc)
@@ -368,6 +369,18 @@ func (pm *ProcessManager) StartProcess(command string, workingDir string, env ma
 }
 
 func (pm *ProcessManager) StartProcessWithName(command string, workingDir string, name string, env map[string]string, restartOnFailure bool, maxRestarts int, keepAlive bool, timeout int, callback func(process *ProcessInfo)) (string, error) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	for _, process := range pm.processes {
+		if process.Name == name {
+			select {
+			case <-process.Finished:
+			default:
+				return process.PID, nil
+			}
+		}
+	}
+
 	// Always use shell to execute commands
 	// This ensures shell built-ins (cd, export, alias) work properly
 	// Use SHELL and SHELL_ARGS environment variables if set
@@ -501,9 +514,7 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 	}
 
 	// Store process in memory
-	pm.mu.Lock()
 	pm.processes[process.PID] = process
-	pm.mu.Unlock()
 
 	// Start file tailer for real-time log streaming
 	go pm.tailLogFiles(process)
@@ -1423,7 +1434,10 @@ func (pm *ProcessManager) getProcessOutput(identifier string, max int64) (Proces
 	if !exists {
 		return ProcessLogs{}, fmt.Errorf("process with PID %s not found", identifier)
 	}
+	return process.output(max), nil
+}
 
+func (process *ProcessInfo) output(max int64) ProcessLogs {
 	// The log files hold the whole output; the in-memory buffers are the
 	// fallback for when a file is gone or unreadable.
 	stdout, ok := readLogTail(process.StdoutFile, max)
@@ -1444,7 +1458,12 @@ func (pm *ProcessManager) getProcessOutput(identifier string, max int64) (Proces
 		Stdout: stdout,
 		Stderr: stderr,
 		Logs:   stdout + stderr,
-	}, nil
+	}
+}
+
+// Output reads process output without mutating shared process state.
+func (process *ProcessInfo) Output() ProcessLogs {
+	return process.output(maxLogsResponse())
 }
 
 // endsWithNewline reports whether the first size bytes of path end a line.

--- a/sandbox-api/src/handler/process/process_test.go
+++ b/sandbox-api/src/handler/process/process_test.go
@@ -24,6 +24,37 @@ func waitForProcessDone(t *testing.T, done <-chan struct{}, timeout time.Duratio
 	}
 }
 
+func TestConcurrentNamedExecutionsShareProcess(t *testing.T) {
+	originalLogDir := ProcessLogDir
+	ProcessLogDir = t.TempDir()
+	t.Cleanup(func() { ProcessLogDir = originalLogDir })
+
+	pm := NewProcessManager()
+	start := make(chan struct{})
+	pids := make(chan string, 16)
+	for range 16 {
+		go func() {
+			<-start
+			process, err := pm.ExecuteProcess("sleep 1", "", "sandboxd", nil, true, 5, nil, false, 0, false)
+			if err != nil {
+				t.Errorf("execute named process: %v", err)
+				pids <- ""
+				return
+			}
+			pids <- process.PID
+		}()
+	}
+	close(start)
+
+	unique := map[string]struct{}{}
+	for range 16 {
+		unique[<-pids] = struct{}{}
+	}
+	if len(unique) != 1 {
+		t.Fatalf("got %d process IDs, want 1: %v", len(unique), unique)
+	}
+}
+
 // TestProcessManagerIntegration tests the complete functionality of the process manager
 // This is an integration test that verifies that real processes can be started, monitored, and stopped
 func TestProcessManagerIntegrationWithPID(t *testing.T) {

--- a/sandbox-api/src/handler/process/service.go
+++ b/sandbox-api/src/handler/process/service.go
@@ -25,26 +25,17 @@ func (pm *ProcessManager) ExecuteProcess(
 	keepAlive bool,
 ) (*ProcessInfo, error) {
 	portCh := make(chan int)
-	completionCh := make(chan string)
 
-	// Add flags to track if channels have been closed
 	portChClosed := false
-	completionChClosed := false
 
-	// Use a mutex to protect the flags
 	var mu sync.Mutex
 
-	// Defer closing the channels if they're not already closed
 	defer func() {
 		mu.Lock()
 		defer mu.Unlock()
 
 		if !portChClosed {
 			close(portCh)
-		}
-
-		if !completionChClosed {
-			close(completionCh)
 		}
 	}()
 
@@ -58,21 +49,7 @@ func (pm *ProcessManager) ExecuteProcess(
 		ctx = context.Background()
 	}
 
-	// Create a callback function
-	callback := func(p *ProcessInfo) {
-		if waitForCompletion {
-			mu.Lock()
-			closed := completionChClosed
-			mu.Unlock()
-			if !closed {
-				// Use a recover block in case of a race condition
-				defer func() {
-					_ = recover()
-				}()
-				completionCh <- p.PID
-			}
-		}
-	}
+	callback := func(*ProcessInfo) {}
 
 	// Start the process
 	var pid string
@@ -84,6 +61,12 @@ func (pm *ProcessManager) ExecuteProcess(
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to start process: %w", err)
+	}
+	pm.mu.RLock()
+	processInfo, exists := pm.processes[pid]
+	pm.mu.RUnlock()
+	if !exists {
+		return nil, fmt.Errorf("process creation failed because process does not exist")
 	}
 
 	// Set up port monitoring if requested
@@ -176,46 +159,9 @@ func (pm *ProcessManager) ExecuteProcess(
 	// Wait for completion if requested
 	if waitForCompletion {
 		select {
-		case receivedPID := <-completionCh:
-			_, exists := pm.GetProcessByIdentifier(receivedPID)
-			if !exists {
-				return nil, fmt.Errorf("process creation failed because process does not exist")
-			}
-			pid = receivedPID // Update pid to the received PID
-			break
+		case <-processInfo.Finished:
 		case <-ctx.Done():
-			// Process timed out but is still running - return process info along with error
-			// so the caller can still access the running process
-			processInfo, exists := pm.GetProcessByIdentifier(pid)
-			if exists {
-				logs := processInfo.logs.String()
-				processInfo.Logs = &logs
-				return processInfo, fmt.Errorf("process timed out after %d seconds", timeout)
-			}
-			return nil, fmt.Errorf("process timed out after %d seconds", timeout)
-		}
-	}
-
-	// Get the process info
-	processInfo, exists := pm.GetProcessByIdentifier(pid)
-	if !exists {
-		return nil, fmt.Errorf("process creation failed because process does not exist")
-	}
-	if waitForCompletion {
-		// Read logs from file if available (more reliable than in-memory)
-		output, err := pm.GetProcessOutput(pid)
-		if err == nil {
-			processInfo.Logs = &output.Logs
-			processInfo.Stdout = &output.Stdout
-			processInfo.Stderr = &output.Stderr
-		} else {
-			// Fall back to in-memory
-			logs := processInfo.logs.String()
-			processInfo.Logs = &logs
-			stdout := processInfo.stdout.String()
-			processInfo.Stdout = &stdout
-			stderr := processInfo.stderr.String()
-			processInfo.Stderr = &stderr
+			return processInfo, fmt.Errorf("process timed out after %d seconds", timeout)
 		}
 	}
 	return processInfo, nil


### PR DESCRIPTION
Concurrent requests can start more than one process with the same name because the name check and process registration are separate. This change makes named start atomic, reuses the active process and its completion signal, and removes duplicate handler and completion-channel logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core process lifecycle and locking for named starts and wait-for-completion; behavior shifts from error-on-duplicate-name to reuse, which callers may rely on differently.
> 
> **Overview**
> **Named process starts are now atomic and idempotent.** `StartProcessWithName` takes the manager lock up front; if a process with the same name is still active (`Finished` not closed), it returns that process’s PID instead of spawning another. Concurrent callers therefore share one OS process—covered by a new concurrency test.
> 
> **HTTP handlers no longer reject duplicate running names** (that check was racy with registration). **Completion waiting** drops the custom completion channel and blocks on `processInfo.Finished` instead; suspended-restart paths call `markFinished()` where needed. **Responses with `waitForCompletion`** fill stdout/stderr/logs via read-only `ProcessInfo.Output()` rather than mutating in-memory buffers in the service layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f926c15dca7bef3ea50cda0e6e3a693cc778d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->