### PR TITLE
Add pipe-based stdin to sandbox processes

### DIFF
--- a/sandbox-api/docs/STDIN.md
+++ b/sandbox-api/docs/STDIN.md
@@ -1,0 +1,70 @@
+# Process stdin
+
+`POST /process` runs a command with stdout and stderr going to log files. By
+default the process has no stdin (it reads EOF at once). Set `"stdin": true` to
+give it a writable pipe instead, then drive it over HTTP. This is what a stdio
+protocol such as MCP needs: raw bytes in, raw lines out, no PTY in between.
+
+## API
+
+| Call | Effect |
+|---|---|
+| `POST /process` with `{"command": "...", "name": "...", "stdin": true}` | Start the process with a stdin pipe. The response carries `"stdin": true`. |
+| `POST /process/{name}/stdin` with a raw body | Write the body verbatim to stdin. Include the trailing newline your protocol expects. Max 8 MiB per call. |
+| `GET /process/{name}/logs/stream` | Read stdout. Lines are tagged `stdout:` / `stderr:`; drop the tag and ignore `[keepalive]` lines. |
+| `DELETE /process/{name}/stdin` | Close stdin (EOF). Idempotent. For MCP this is the clean shutdown. |
+
+Errors:
+
+- `404` unknown process.
+- `409` the process was started without `stdin: true`, or its stdin is already
+  closed (see below). The message says which.
+- `413` body over 8 MiB.
+
+Sequential writes keep their order. Each body is written under one lock, so two
+concurrent writers never interleave inside a message.
+
+## Restart behaviour
+
+- **Restart on failure** (`restartOnFailure: true`): each run gets a fresh pipe.
+  Writes after the restart reach the new child. Anything written between the
+  failure and the restart is lost with the old pipe.
+- **sandbox-api restart** (OOM, crash, upgrade): the pipe lives in sandbox-api,
+  so it dies with it. The child reads EOF, which for a stdio server means
+  "shut down". The process is re-attached on the next start and still reports
+  `"stdin": true`, but writes return `409 stdin is closed`. Restart the process
+  and re-run your protocol handshake.
+- **Sandbox scale-to-zero / resume**: the whole VM is snapshotted, pipe
+  included. Nothing to do.
+
+A pipe rather than a FIFO on disk is a deliberate trade: stdin survival across a
+sandbox-api restart would buy little, since the client's log stream drops at the
+same moment and any stdio session has to be re-initialised anyway.
+
+## Example: an MCP server over stdio
+
+```sh
+BASE=http://localhost:8080
+
+curl -s $BASE/process -H 'Content-Type: application/json' -d '{
+  "name": "mcp-fs",
+  "command": "npx -y @modelcontextprotocol/server-filesystem /tmp",
+  "stdin": true
+}'
+
+# Follow stdout in another shell, keeping only stdout lines:
+curl -sN $BASE/process/mcp-fs/logs/stream | sed -n 's/^stdout://p'
+
+curl -s $BASE/process/mcp-fs/stdin --data-binary \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}
+'
+curl -s $BASE/process/mcp-fs/stdin --data-binary '{"jsonrpc":"2.0","method":"notifications/initialized"}
+'
+curl -s $BASE/process/mcp-fs/stdin --data-binary '{"jsonrpc":"2.0","id":2,"method":"tools/list"}
+'
+
+curl -s -X DELETE $BASE/process/mcp-fs/stdin
+```
+
+To use an MCP SDK's stdio transport unchanged, run a small local shim whose own
+stdin/stdout are bridged to these two calls, and point the transport at the shim.

--- a/sandbox-api/docs/STDIN.md
+++ b/sandbox-api/docs/STDIN.md
@@ -18,11 +18,24 @@ Errors:
 
 - `404` unknown process.
 - `409` the process was started without `stdin: true`, or its stdin is already
-  closed (see below). The message says which.
-- `413` body over 8 MiB.
+  closed: explicit `DELETE`, process exited, or sandbox-api restarted (see
+  below). The message says which.
+- `413` body over 8 MiB. `400` for a body that could not be read.
+- `503` the process stopped reading its stdin: the pipe buffer stayed full for
+  10 seconds. Part of the body may have gone through, so treat the stream as
+  suspect and restart the process if it does not recover.
 
 Sequential writes keep their order. Each body is written under one lock, so two
-concurrent writers never interleave inside a message.
+concurrent writers never interleave inside a message. A write holds that lock
+for at most the 10 second deadline, so one stuck writer cannot pin the others.
+
+Writes and closes are audited as `process_stdin_write` (byte count only, never
+the body) and `process_stdin_close`; `process_exec` records whether stdin was
+requested.
+
+`DISABLE_TERMINAL` does not affect these routes. It removes the web PTY, while
+`POST /process` already runs arbitrary commands with or without stdin; a pipe
+adds no capability the process API did not have.
 
 ## Restart behaviour
 
@@ -36,6 +49,9 @@ concurrent writers never interleave inside a message.
   and re-run your protocol handshake.
 - **Sandbox scale-to-zero / resume**: the whole VM is snapshotted, pipe
   included. Nothing to do.
+- **Relaunch from an archive**: a process restored at boot from the archived
+  state is started with the same `stdin` flag it had, so it gets a fresh pipe.
+  The protocol handshake has to be redone, as after any restart.
 
 A pipe rather than a FIFO on disk is a deliberate trade: stdin survival across a
 sandbox-api restart would buy little, since the client's log stream drops at the

--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -1909,8 +1909,20 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
+                    "413": {
+                        "description": "Body over 8 MiB",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Write failed",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Process stopped reading its stdin",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/sandbox-api/docs/docs.go
+++ b/sandbox-api/docs/docs.go
@@ -1743,6 +1743,104 @@ const docTemplate = `{
                 }
             }
         },
+        "/process/{identifier}/stdin": {
+            "post": {
+                "description": "Write the raw request body to the stdin of a process started with \"stdin\": true. Bytes are forwarded verbatim, so include the trailing newline your protocol expects. Sequential requests keep their order; each body is written atomically with respect to other writers. The pipe does not survive a sandbox-api restart: once it is gone this returns 409 and the process must be restarted.",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "process"
+                ],
+                "summary": "Write to a process's stdin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Process identifier (PID or name)",
+                        "name": "identifier",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Raw bytes to write",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Bytes written",
+                        "schema": {
+                            "$ref": "#/definitions/SuccessResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Process not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Process has no stdin, or stdin is closed",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Write failed",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Send EOF to the process by closing its stdin pipe. Idempotent. For stdio protocols such as MCP this is the clean shutdown path.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "process"
+                ],
+                "summary": "Close a process's stdin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Process identifier (PID or name)",
+                        "name": "identifier",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Stdin closed",
+                        "schema": {
+                            "$ref": "#/definitions/SuccessResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Process not found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Process has no stdin",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/upgrade": {
             "post": {
                 "description": "Triggers an upgrade of the sandbox-api process. Returns 200 immediately before upgrading.\nThe upgrade will: download the specified binary from GitHub releases, validate it, and restart.\nAll running processes will be preserved across the upgrade.\nAvailable versions: \"latest\" (default, most recent release), \"develop\", \"main\", or specific tag like \"v1.0.0\"\nYou can also specify a custom baseUrl for forks (defaults to https://github.com/blaxel-ai/sandbox/releases)",
@@ -2479,6 +2577,11 @@ const docTemplate = `{
                     "type": "boolean",
                     "example": true
                 },
+                "stdin": {
+                    "description": "Open a writable stdin pipe, fed via POST /process/{identifier}/stdin and closed via DELETE. The pipe does not survive a sandbox-api restart: the process then sees EOF.",
+                    "type": "boolean",
+                    "example": false
+                },
                 "timeout": {
                     "description": "Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).",
                     "type": "integer",
@@ -2579,6 +2682,11 @@ const docTemplate = `{
                 "stderr": {
                     "type": "string",
                     "example": "stderr output"
+                },
+                "stdin": {
+                    "description": "Whether the process was started with a writable stdin pipe",
+                    "type": "boolean",
+                    "example": false
                 },
                 "stdout": {
                     "type": "string",

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -1586,8 +1586,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "413":
+          description: Body over 8 MiB
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Write failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: Process stopped reading its stdin
           content:
             application/json:
               schema:

--- a/sandbox-api/docs/openapi.yml
+++ b/sandbox-api/docs/openapi.yml
@@ -1424,6 +1424,82 @@ paths:
       summary: Stream process logs in real time
       tags:
         - process
+  "/process/{identifier}/stdin":
+    delete:
+      description: Send EOF to the process by closing its stdin pipe. Idempotent. For stdio protocols such as MCP this is the clean shutdown path.
+      parameters:
+        - description: Process identifier (PID or name)
+          in: path
+          name: identifier
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Stdin closed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "404":
+          description: Process not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Process has no stdin
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      summary: Close a process's stdin
+      tags:
+        - process
+    post:
+      description: 'Write the raw request body to the stdin of a process started with "stdin": true. Bytes are forwarded verbatim, so include the trailing newline your protocol expects. Sequential requests keep their order; each body is written atomically with respect to other writers. The pipe does not survive a sandbox-api restart: once it is gone this returns 409 and the process must be restarted.'
+      parameters:
+        - description: Process identifier (PID or name)
+          in: path
+          name: identifier
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+        description: Raw bytes to write
+        required: true
+      responses:
+        "200":
+          description: Bytes written
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessResponse"
+        "404":
+          description: Process not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Process has no stdin, or stdin is closed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Write failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+      summary: Write to a process's stdin
+      tags:
+        - process
   /upgrade:
     post:
       description: >-
@@ -1981,6 +2057,10 @@ components:
         restartOnFailure:
           example: true
           type: boolean
+        stdin:
+          description: "Open a writable stdin pipe, fed via POST /process/{identifier}/stdin and closed via DELETE. The pipe does not survive a sandbox-api restart: the process then sees EOF."
+          example: false
+          type: boolean
         timeout:
           description: Timeout in seconds. When keepAlive is true, defaults to 600s (10 minutes). Set to 0 for infinite (no auto-kill).
           example: 30
@@ -2049,6 +2129,10 @@ components:
         stderr:
           example: stderr output
           type: string
+        stdin:
+          description: Whether the process was started with a writable stdin pipe
+          example: false
+          type: boolean
         stdout:
           example: stdout output
           type: string

--- a/sandbox-api/integration-tests/common/request.go
+++ b/sandbox-api/integration-tests/common/request.go
@@ -284,3 +284,16 @@ func EncodeFilesystemFindPath(path string) string {
 	// For relative paths, just append to /filesystem-find/
 	return "/filesystem-find/" + path
 }
+
+// MakeRawRequest sends body as-is with the given Content-Type, for endpoints
+// that take bytes rather than JSON (process stdin).
+func MakeRawRequest(method, path string, body io.Reader, contentType string) (*http.Response, error) {
+	req, err := http.NewRequest(method, BaseURL+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return Client.Do(req)
+}

--- a/sandbox-api/integration-tests/tests/process/stdin_test.go
+++ b/sandbox-api/integration-tests/tests/process/stdin_test.go
@@ -1,0 +1,178 @@
+package tests
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blaxel-ai/sandbox-api/integration_tests/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startWithStdin starts a named process with a stdin pipe and kills it on cleanup.
+func startWithStdin(t *testing.T, name, command string) {
+	t.Helper()
+	resp, err := common.MakeRequest(http.MethodPost, "/process", map[string]any{
+		"name":    name,
+		"command": command,
+		"stdin":   true,
+	})
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var proc map[string]any
+	require.NoError(t, common.ParseJSONResponse(resp, &proc))
+	assert.Equal(t, true, proc["stdin"], "response should report the stdin pipe")
+	t.Cleanup(func() {
+		r, err := common.MakeRequest(http.MethodDelete, "/process/"+name+"/kill", nil)
+		if err == nil {
+			r.Body.Close()
+		}
+	})
+}
+
+// stdoutLines follows the process log stream and yields raw stdout lines: the
+// "stdout:" tag stripped, stderr and keepalives dropped. This is exactly what a
+// stdio client has to do on its side.
+func stdoutLines(t *testing.T, name string) <-chan string {
+	t.Helper()
+	resp, err := common.MakeRequestWithTimeout(http.MethodGet, "/process/"+name+"/logs/stream", nil, 60*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	out := make(chan string, 64)
+	go func() {
+		defer close(out)
+		sc := bufio.NewScanner(resp.Body)
+		sc.Buffer(make([]byte, 1<<20), 1<<20)
+		for sc.Scan() {
+			if line, ok := strings.CutPrefix(sc.Text(), "stdout:"); ok {
+				out <- line
+			}
+		}
+	}()
+	return out
+}
+
+func writeStdin(t *testing.T, name, line string) *http.Response {
+	t.Helper()
+	resp, err := common.MakeRawRequest(http.MethodPost, "/process/"+name+"/stdin", strings.NewReader(line+"\n"), "application/octet-stream")
+	require.NoError(t, err)
+	resp.Body.Close()
+	return resp
+}
+
+// waitJSONRPC returns the first JSON-RPC message on the stream with the given id.
+func waitJSONRPC(t *testing.T, lines <-chan string, id int) map[string]any {
+	t.Helper()
+	deadline := time.After(30 * time.Second)
+	for {
+		select {
+		case line, ok := <-lines:
+			require.True(t, ok, "stream closed before response id %d", id)
+			var msg map[string]any
+			if json.Unmarshal([]byte(line), &msg) == nil && msg["id"] == float64(id) {
+				return msg
+			}
+		case <-deadline:
+			t.Fatalf("no JSON-RPC response with id %d", id)
+		}
+	}
+}
+
+func processStatus(t *testing.T, name string) string {
+	t.Helper()
+	var proc map[string]any
+	resp, err := common.MakeRequestAndParse(http.MethodGet, "/process/"+name, nil, &proc)
+	require.NoError(t, err)
+	resp.Body.Close()
+	status, _ := proc["status"].(string)
+	return status
+}
+
+// A deterministic stdio server: a shell loop answering every request with a
+// fixed result. No network, no runtime beyond sh, so it runs in CI.
+func TestStdinJSONRPCRoundTrip(t *testing.T) {
+	name := uniqueProcessName("stdin-echo")
+	startWithStdin(t, name, `while IFS= read -r l; do id=$(printf '%s' "$l" | sed -n 's/.*"id":\([0-9]*\).*/\1/p'); echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"echo\":$l}}"; done`)
+	lines := stdoutLines(t, name)
+
+	resp := writeStdin(t, name, `{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	msg := waitJSONRPC(t, lines, 1)
+	result := msg["result"].(map[string]any)
+	// The request came back intact inside the reply: no echo, no escape codes.
+	assert.Equal(t, "ping", result["echo"].(map[string]any)["method"])
+
+	// Order is preserved across sequential writes.
+	writeStdin(t, name, `{"jsonrpc":"2.0","id":2,"method":"a"}`)
+	writeStdin(t, name, `{"jsonrpc":"2.0","id":3,"method":"b"}`)
+	assert.Equal(t, float64(2), waitJSONRPC(t, lines, 2)["id"])
+	assert.Equal(t, float64(3), waitJSONRPC(t, lines, 3)["id"])
+
+	// EOF ends the loop: the documented shutdown path.
+	resp, err := common.MakeRequest(http.MethodDelete, "/process/"+name+"/stdin", nil)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Eventually(t, func() bool { return processStatus(t, name) == "completed" },
+		10*time.Second, 200*time.Millisecond, "process should exit on stdin EOF")
+
+	// After EOF the pipe is gone for good.
+	resp = writeStdin(t, name, "late")
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+}
+
+// A process started without stdin refuses writes with 409, not 500.
+func TestStdinNotEnabled(t *testing.T) {
+	name := uniqueProcessName("no-stdin")
+	resp, err := common.MakeRequest(http.MethodPost, "/process", map[string]any{"name": name, "command": "sleep 5"})
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	t.Cleanup(func() {
+		if r, err := common.MakeRequest(http.MethodDelete, "/process/"+name+"/kill", nil); err == nil {
+			r.Body.Close()
+		}
+	})
+
+	resp = writeStdin(t, name, "x")
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+
+	resp = writeStdin(t, uniqueProcessName("ghost"), "x")
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// The real thing: an MCP server over stdio, driven through the API. Needs node
+// and network access in the image, so it is opt-in.
+func TestStdinRealMCPServer(t *testing.T) {
+	if os.Getenv("MCP_STDIO_TEST") == "" {
+		t.Skip("set MCP_STDIO_TEST=1 to run against a real stdio MCP server (needs node + network)")
+	}
+	name := uniqueProcessName("mcp-fs")
+	startWithStdin(t, name, "npx -y @modelcontextprotocol/server-filesystem /tmp")
+	lines := stdoutLines(t, name)
+
+	writeStdin(t, name, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"sandbox-api-it","version":"0"}}}`)
+	init := waitJSONRPC(t, lines, 1)
+	require.NotNil(t, init["result"], "initialize failed: %v", init["error"])
+	assert.NotEmpty(t, init["result"].(map[string]any)["serverInfo"])
+
+	writeStdin(t, name, `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	writeStdin(t, name, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	toolsResp := waitJSONRPC(t, lines, 2)
+	require.NotNil(t, toolsResp["result"], "tools/list failed: %v", toolsResp["error"])
+	assert.NotEmpty(t, toolsResp["result"].(map[string]any)["tools"])
+
+	resp, err := common.MakeRequest(http.MethodDelete, "/process/"+name+"/stdin", nil)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Eventually(t, func() bool { return processStatus(t, name) != "running" },
+		15*time.Second, 200*time.Millisecond, "MCP server should shut down on stdin EOF")
+}

--- a/sandbox-api/src/api/router.go
+++ b/sandbox-api/src/api/router.go
@@ -156,6 +156,8 @@ func SetupRouter(disableRequestLogging bool, enableProcessingTime bool) *gin.Eng
 	r.HEAD("/process/:identifier/logs", head)
 	r.GET("/process/:identifier/logs/stream", processHandler.HandleGetProcessLogsStream)
 	r.HEAD("/process/:identifier/logs/stream", head)
+	r.POST("/process/:identifier/stdin", processHandler.HandleWriteStdin)
+	r.DELETE("/process/:identifier/stdin", processHandler.HandleCloseStdin)
 	r.DELETE("/process/:identifier", processHandler.HandleStopProcess)
 	r.DELETE("/process/:identifier/kill", processHandler.HandleKillProcess)
 	r.GET("/process/:identifier", processHandler.HandleGetProcess)

--- a/sandbox-api/src/handler/archive/import.go
+++ b/sandbox-api/src/handler/archive/import.go
@@ -1124,6 +1124,7 @@ func relaunch(root string, state []byte) (relaunched, failed []string) {
 			archived.MaxRestarts,
 			archived.KeepAlive,
 			archived.Timeout,
+			archived.Stdin,
 			// The process manager calls the completion callback unconditionally,
 			// so a relaunched process exiting must find something to call.
 			func(finished *process.ProcessInfo) {

--- a/sandbox-api/src/handler/archive/import_test.go
+++ b/sandbox-api/src/handler/archive/import_test.go
@@ -354,7 +354,7 @@ func TestRelaunchDoesNotStartASecondCopyOfAProcessNamedLikeANumber(t *testing.T)
 	// number is a PID for whoever looks a process up by identifier. A resumed
 	// relaunch that misses the running process starts the workload twice.
 	pm := process.GetProcessManager()
-	live, err := pm.StartProcessWithName("sleep 30", "", "42", nil, false, 0, false, 0, func(*process.ProcessInfo) {})
+	live, err := pm.StartProcessWithName("sleep 30", "", "42", nil, false, 0, false, 0, false, func(*process.ProcessInfo) {})
 	if err != nil {
 		t.Fatalf("failed to start the process the archive also carries: %v", err)
 	}

--- a/sandbox-api/src/handler/process.go
+++ b/sandbox-api/src/handler/process.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -62,6 +63,7 @@ type ProcessRequest struct {
 	RestartOnFailure  bool              `json:"restartOnFailure" example:"true"`
 	MaxRestarts       int               `json:"maxRestarts" example:"3"`   // Maximum number of restarts on failure. Set to a negative value (e.g. -1) for unlimited restarts.
 	KeepAlive         bool              `json:"keepAlive" example:"false"` // Disable scale-to-zero while process runs. Default timeout is 600s (10 minutes). Set timeout to 0 for infinite.
+	Stdin             bool              `json:"stdin" example:"false"`     // Open a writable stdin pipe, fed via POST /process/{identifier}/stdin and closed via DELETE. The pipe does not survive a sandbox-api restart: the process then sees EOF.
 } // @name ProcessRequest
 
 // ProcessResponse is the response body for a process
@@ -81,6 +83,7 @@ type ProcessResponse struct {
 	MaxRestarts      int     `json:"maxRestarts" example:"3"`
 	RestartCount     int     `json:"restartCount" example:"2"`
 	KeepAlive        bool    `json:"keepAlive" example:"false"` // Whether scale-to-zero is disabled for this process
+	Stdin            bool    `json:"stdin" example:"false"`     // Whether the process was started with a writable stdin pipe
 } // @name ProcessResponse
 
 type ProcessResponseWithLogs struct {
@@ -94,11 +97,11 @@ type ProcessKillRequest struct {
 } // @name ProcessKillRequest
 
 // ExecuteProcess executes a process
-func (h *ProcessHandler) ExecuteProcess(command string, workingDir string, name string, env map[string]string, waitForCompletion bool, timeout int, waitForPorts []int, restartOnFailure bool, maxRestarts int, keepAlive bool) (ProcessResponse, error) {
+func (h *ProcessHandler) ExecuteProcess(command string, workingDir string, name string, env map[string]string, waitForCompletion bool, timeout int, waitForPorts []int, restartOnFailure bool, maxRestarts int, keepAlive bool, stdin bool) (ProcessResponse, error) {
 	if keepAlive && blaxel.KeepAliveDisabled() {
 		return ProcessResponse{}, ErrKeepAliveDisabled
 	}
-	processInfo, err := h.processManager.ExecuteProcess(command, workingDir, name, env, waitForCompletion, timeout, waitForPorts, restartOnFailure, maxRestarts, keepAlive)
+	processInfo, err := h.processManager.ExecuteProcess(command, workingDir, name, env, waitForCompletion, timeout, waitForPorts, restartOnFailure, maxRestarts, keepAlive, stdin)
 
 	// If processInfo is nil (process failed to start), return empty response with error
 	if processInfo == nil {
@@ -128,6 +131,7 @@ func (h *ProcessHandler) ExecuteProcess(command string, workingDir string, name 
 		MaxRestarts:      processInfo.MaxRestarts,
 		RestartCount:     processInfo.RestartCount,
 		KeepAlive:        processInfo.KeepAlive,
+		Stdin:            processInfo.Stdin,
 	}, err
 }
 
@@ -325,7 +329,7 @@ func (h *ProcessHandler) HandleExecuteCommand(c *gin.Context) {
 	}
 
 	// Execute the process
-	processInfo, err := h.ExecuteProcess(req.Command, req.WorkingDir, req.Name, req.Env, req.WaitForCompletion, timeout, req.WaitForPorts, req.RestartOnFailure, req.MaxRestarts, req.KeepAlive)
+	processInfo, err := h.ExecuteProcess(req.Command, req.WorkingDir, req.Name, req.Env, req.WaitForCompletion, timeout, req.WaitForPorts, req.RestartOnFailure, req.MaxRestarts, req.KeepAlive, req.Stdin)
 	if err != nil {
 		h.SendError(c, http.StatusUnprocessableEntity, err)
 		return
@@ -392,7 +396,7 @@ func (h *ProcessHandler) handleExecuteCommandStream(c *gin.Context) {
 	jw := &JSONStreamWriter{gin: c}
 
 	// Execute the process without waiting for completion (we'll handle waiting ourselves)
-	processInfo, err := h.ExecuteProcess(req.Command, req.WorkingDir, req.Name, req.Env, false, timeout, req.WaitForPorts, req.RestartOnFailure, req.MaxRestarts, req.KeepAlive)
+	processInfo, err := h.ExecuteProcess(req.Command, req.WorkingDir, req.Name, req.Env, false, timeout, req.WaitForPorts, req.RestartOnFailure, req.MaxRestarts, req.KeepAlive, req.Stdin)
 	if err != nil {
 		jw.WriteEvent("error", err.Error())
 		return
@@ -648,6 +652,77 @@ func (h *ProcessHandler) HandleKillProcess(c *gin.Context) {
 	}
 
 	h.SendJSON(c, http.StatusOK, gin.H{"message": "Process killed successfully"})
+}
+
+// maxStdinBody caps one stdin write. Callers stream stdio protocols one message
+// at a time, so a single body this large is a bug, not a use case.
+const maxStdinBody = 8 << 20
+
+// stdinErrorStatus maps a stdin error to an HTTP status: 404 for an unknown
+// process, 409 when the pipe is absent or gone, 500 for a failed write.
+func stdinErrorStatus(err error) int {
+	switch {
+	case errors.Is(err, process.ErrStdinNotEnabled), errors.Is(err, process.ErrStdinClosed):
+		return http.StatusConflict
+	case strings.Contains(err.Error(), "not found"):
+		return http.StatusNotFound
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// HandleWriteStdin handles POST requests to /process/:identifier/stdin
+// @Summary Write to a process's stdin
+// @Description Write the raw request body to the stdin of a process started with "stdin": true. Bytes are forwarded verbatim, so include the trailing newline your protocol expects. Sequential requests keep their order; each body is written atomically with respect to other writers. The pipe does not survive a sandbox-api restart: once it is gone this returns 409 and the process must be restarted.
+// @Tags process
+// @Accept octet-stream
+// @Produce json
+// @Param identifier path string true "Process identifier (PID or name)"
+// @Param body body string true "Raw bytes to write"
+// @Success 200 {object} SuccessResponse "Bytes written"
+// @Failure 404 {object} ErrorResponse "Process not found"
+// @Failure 409 {object} ErrorResponse "Process has no stdin, or stdin is closed"
+// @Failure 500 {object} ErrorResponse "Write failed"
+// @Router /process/{identifier}/stdin [post]
+func (h *ProcessHandler) HandleWriteStdin(c *gin.Context) {
+	identifier, err := h.GetPathParam(c, "identifier")
+	if err != nil {
+		h.SendError(c, http.StatusBadRequest, err)
+		return
+	}
+	data, err := io.ReadAll(http.MaxBytesReader(c.Writer, c.Request.Body, maxStdinBody))
+	if err != nil {
+		h.SendError(c, http.StatusRequestEntityTooLarge, err)
+		return
+	}
+	if err := h.processManager.WriteStdin(identifier, data); err != nil {
+		h.SendError(c, stdinErrorStatus(err), err)
+		return
+	}
+	h.SendJSON(c, http.StatusOK, gin.H{"message": "Bytes written to stdin"})
+}
+
+// HandleCloseStdin handles DELETE requests to /process/:identifier/stdin
+// @Summary Close a process's stdin
+// @Description Send EOF to the process by closing its stdin pipe. Idempotent. For stdio protocols such as MCP this is the clean shutdown path.
+// @Tags process
+// @Produce json
+// @Param identifier path string true "Process identifier (PID or name)"
+// @Success 200 {object} SuccessResponse "Stdin closed"
+// @Failure 404 {object} ErrorResponse "Process not found"
+// @Failure 409 {object} ErrorResponse "Process has no stdin"
+// @Router /process/{identifier}/stdin [delete]
+func (h *ProcessHandler) HandleCloseStdin(c *gin.Context) {
+	identifier, err := h.GetPathParam(c, "identifier")
+	if err != nil {
+		h.SendError(c, http.StatusBadRequest, err)
+		return
+	}
+	if err := h.processManager.CloseStdin(identifier); err != nil {
+		h.SendError(c, stdinErrorStatus(err), err)
+		return
+	}
+	h.SendJSON(c, http.StatusOK, gin.H{"message": "Stdin closed"})
 }
 
 // HandleGetProcess handles GET requests to /process/:identifier

--- a/sandbox-api/src/handler/process.go
+++ b/sandbox-api/src/handler/process.go
@@ -175,6 +175,7 @@ func (h *ProcessHandler) ListProcesses() []ProcessResponse {
 			MaxRestarts:      p.MaxRestarts,
 			RestartCount:     p.RestartCount,
 			KeepAlive:        p.KeepAlive,
+			Stdin:            p.Stdin,
 		})
 	}
 	return result
@@ -222,6 +223,7 @@ func (h *ProcessHandler) GetProcess(identifier string) (ProcessResponse, error) 
 		MaxRestarts:      processInfo.MaxRestarts,
 		RestartCount:     processInfo.RestartCount,
 		KeepAlive:        processInfo.KeepAlive,
+		Stdin:            processInfo.Stdin,
 	}, nil
 }
 
@@ -316,6 +318,7 @@ func (h *ProcessHandler) HandleExecuteCommand(c *gin.Context) {
 	audit.LogEvent(c, "process_exec", logrus.Fields{
 		"command":     req.Command,
 		"working-dir": req.WorkingDir,
+		"stdin":       req.Stdin,
 	})
 
 	// Timeout of 0 means infinite (no auto-kill)
@@ -373,6 +376,7 @@ func (h *ProcessHandler) handleExecuteCommandStream(c *gin.Context) {
 	audit.LogEvent(c, "process_exec_stream", logrus.Fields{
 		"command":     req.Command,
 		"working-dir": req.WorkingDir,
+		"stdin":       req.Stdin,
 	})
 
 	// Timeout of 0 means infinite (no auto-kill)
@@ -659,11 +663,14 @@ func (h *ProcessHandler) HandleKillProcess(c *gin.Context) {
 const maxStdinBody = 8 << 20
 
 // stdinErrorStatus maps a stdin error to an HTTP status: 404 for an unknown
-// process, 409 when the pipe is absent or gone, 500 for a failed write.
+// process, 409 when the pipe is absent or gone, 503 when the child is not
+// reading, 500 for a failed write.
 func stdinErrorStatus(err error) int {
 	switch {
 	case errors.Is(err, process.ErrStdinNotEnabled), errors.Is(err, process.ErrStdinClosed):
 		return http.StatusConflict
+	case errors.Is(err, process.ErrStdinStalled):
+		return http.StatusServiceUnavailable
 	case strings.Contains(err.Error(), "not found"):
 		return http.StatusNotFound
 	default:
@@ -682,7 +689,9 @@ func stdinErrorStatus(err error) int {
 // @Success 200 {object} SuccessResponse "Bytes written"
 // @Failure 404 {object} ErrorResponse "Process not found"
 // @Failure 409 {object} ErrorResponse "Process has no stdin, or stdin is closed"
+// @Failure 413 {object} ErrorResponse "Body over 8 MiB"
 // @Failure 500 {object} ErrorResponse "Write failed"
+// @Failure 503 {object} ErrorResponse "Process stopped reading its stdin"
 // @Router /process/{identifier}/stdin [post]
 func (h *ProcessHandler) HandleWriteStdin(c *gin.Context) {
 	identifier, err := h.GetPathParam(c, "identifier")
@@ -692,9 +701,16 @@ func (h *ProcessHandler) HandleWriteStdin(c *gin.Context) {
 	}
 	data, err := io.ReadAll(http.MaxBytesReader(c.Writer, c.Request.Body, maxStdinBody))
 	if err != nil {
-		h.SendError(c, http.StatusRequestEntityTooLarge, err)
+		var tooBig *http.MaxBytesError
+		if errors.As(err, &tooBig) {
+			h.SendError(c, http.StatusRequestEntityTooLarge, err)
+		} else {
+			h.SendError(c, http.StatusBadRequest, err)
+		}
 		return
 	}
+	// The body itself may carry secrets, so only its size is audited.
+	audit.LogEvent(c, "process_stdin_write", logrus.Fields{"identifier": identifier, "bytes": len(data)})
 	if err := h.processManager.WriteStdin(identifier, data); err != nil {
 		h.SendError(c, stdinErrorStatus(err), err)
 		return
@@ -718,6 +734,7 @@ func (h *ProcessHandler) HandleCloseStdin(c *gin.Context) {
 		h.SendError(c, http.StatusBadRequest, err)
 		return
 	}
+	audit.LogEvent(c, "process_stdin_close", logrus.Fields{"identifier": identifier})
 	if err := h.processManager.CloseStdin(identifier); err != nil {
 		h.SendError(c, stdinErrorStatus(err), err)
 		return

--- a/sandbox-api/src/handler/process/finished_on_restart_test.go
+++ b/sandbox-api/src/handler/process/finished_on_restart_test.go
@@ -21,7 +21,7 @@ func TestFinishedStaysOpenAcrossRestart(t *testing.T) {
 	proc, err := pm.ExecuteProcess(
 		"sh -c '"+cmd+"'", "", "restarter",
 		map[string]string{"MARKER": ProcessLogDir + "/once"},
-		false, 0, nil, true, 3, false,
+		false, 0, nil, true, 3, false, false,
 	)
 	if err != nil {
 		t.Fatalf("starting process: %v", err)
@@ -87,7 +87,7 @@ func TestFinishedClosesWithoutRestart(t *testing.T) {
 	t.Cleanup(func() { ProcessLogDir = originalLogDir })
 	pm := NewProcessManager()
 
-	proc, err := pm.ExecuteProcess("sh -c 'echo hi'", "", "oneshot", nil, false, 0, nil, false, 0, false)
+	proc, err := pm.ExecuteProcess("sh -c 'echo hi'", "", "oneshot", nil, false, 0, nil, false, 0, false, false)
 	if err != nil {
 		t.Fatalf("starting process: %v", err)
 	}

--- a/sandbox-api/src/handler/process/interleave_test.go
+++ b/sandbox-api/src/handler/process/interleave_test.go
@@ -50,3 +50,25 @@ func lineStarts(s string) []string {
 	}
 	return starts
 }
+
+// Finishing the current line must not turn into never leaving stdout: a child
+// that streams newline-free output forever still lets stderr through. In
+// practice the tailer outruns the writer and yields at EOF anyway, so this
+// mostly pins the loop's exit conditions; maxDrainReads is what guards a writer
+// that keeps up.
+func TestEndlessStdoutDoesNotStarveStderr(t *testing.T) {
+	pm := newStdinTestManager(t)
+	w := &captureWriter{}
+	cmd := `echo "to stderr" >&2; exec cat /dev/zero | tr "\0" x`
+	pid, err := pm.StartProcess(cmd, "", nil, false, 0, false, 0, false, noop)
+	if err != nil {
+		t.Fatalf("starting process: %v", err)
+	}
+	t.Cleanup(func() { _ = pm.KillProcess(pid) })
+	if err := pm.StreamProcessOutput(pid, w); err != nil {
+		t.Fatalf("attaching writer: %v", err)
+	}
+	waitFor(t, "stderr line while stdout streams", func() bool {
+		return strings.Contains(w.String(), "stderr:to stderr\n")
+	})
+}

--- a/sandbox-api/src/handler/process/interleave_test.go
+++ b/sandbox-api/src/handler/process/interleave_test.go
@@ -1,0 +1,52 @@
+package process
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// A stdout line longer than the read buffer and a stderr line written at the
+// same time must reach a text consumer as two whole lines. The tailer used to
+// read the streams in turns, so the stderr line landed at byte 4096 of the
+// stdout line; an MCP server logging to stderr while answering tools/list
+// produced exactly that.
+func TestLongStdoutLineIsNotSplicedByStderr(t *testing.T) {
+	pm := newStdinTestManager(t)
+	w := &captureWriter{}
+	// Build the line first so its single write lands in one go, then stderr,
+	// then stdout: the order the tailer used to get wrong.
+	cmd := `x=$(head -c 9000 /dev/zero | tr "\0" x); echo "to stderr" >&2; printf '%s\n' "$x"; sleep 1`
+	pid, err := pm.StartProcess(cmd, "", nil, false, 0, false, 0, false, noop)
+	if err != nil {
+		t.Fatalf("starting process: %v", err)
+	}
+	if err := pm.StreamProcessOutput(pid, w); err != nil {
+		t.Fatalf("attaching writer: %v", err)
+	}
+	proc, _ := pm.GetProcessByIdentifier(pid)
+	select {
+	case <-proc.Finished:
+	case <-time.After(15 * time.Second):
+		t.Fatal("process did not finish")
+	}
+	<-proc.TailDone
+
+	out := w.String()
+	for _, want := range []string{"stdout:" + strings.Repeat("x", 9000) + "\n", "stderr:to stderr\n"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("line spliced: %q missing from stream; stream starts of lines: %v", want[:20], lineStarts(out))
+		}
+	}
+}
+
+func lineStarts(s string) []string {
+	var starts []string
+	for _, l := range strings.Split(s, "\n") {
+		if len(l) > 24 {
+			l = l[:24] + "…"
+		}
+		starts = append(starts, l)
+	}
+	return starts
+}

--- a/sandbox-api/src/handler/process/logfile_test.go
+++ b/sandbox-api/src/handler/process/logfile_test.go
@@ -160,7 +160,7 @@ func TestProcessOutputComesFromDiskAndTheTailIsBounded(t *testing.T) {
 	// ~200 KiB of output: more than the in-memory buffer holds, so it can only
 	// be returned in full if it is read from the log file.
 	command := `for i in $(seq 1 200); do for j in $(seq 1 1024); do printf 'Z'; done; done`
-	pid, err := pm.StartProcess(command, "", nil, false, 0, false, 0, func(p *ProcessInfo) { done <- p })
+	pid, err := pm.StartProcess(command, "", nil, false, 0, false, 0, false, func(p *ProcessInfo) { done <- p })
 	if err != nil {
 		t.Fatalf("Error starting process: %v", err)
 	}

--- a/sandbox-api/src/handler/process/process.go
+++ b/sandbox-api/src/handler/process/process.go
@@ -110,10 +110,11 @@ type ProcessInfo struct {
 	MaxRestarts      int                     `json:"maxRestarts"`
 	RestartCount     int                     `json:"restartCount"`
 	KeepAlive        bool                    `json:"keepAlive"`
-	Timeout          int                     `json:"-"` // Internal: timeout in seconds for keepAlive processes
-	LogFile          string                  `json:"-"` // Path to combined log file
-	StdoutFile       string                  `json:"-"` // Path to stdout log file
-	StderrFile       string                  `json:"-"` // Path to stderr log file
+	Stdin            bool                    `json:"stdin"` // Whether the process was started with a writable stdin pipe
+	Timeout          int                     `json:"-"`     // Internal: timeout in seconds for keepAlive processes
+	LogFile          string                  `json:"-"`     // Path to combined log file
+	StdoutFile       string                  `json:"-"`     // Path to stdout log file
+	StderrFile       string                  `json:"-"`     // Path to stderr log file
 	Done             chan struct{}
 	TailDone         chan struct{} // Closed when tailLogFiles finishes its final reads
 	// Finished is closed once the process is over for good, with no restart to
@@ -138,6 +139,7 @@ type ProcessInfo struct {
 	logLock         sync.RWMutex
 	stopTimeout     chan struct{} // Channel to signal timeout goroutine to stop
 	stopTimeoutOnce sync.Once     // Protects stopTimeout channel from double-close
+	stdin           stdinPipe     // Write end of stdin when Stdin is true; nil once closed or after a sandbox-api restart
 }
 
 // ProcessLogDir is the directory where process logs are stored
@@ -258,12 +260,12 @@ func (pm *ProcessManager) sweepLogFiles() {
 	}
 }
 
-func (pm *ProcessManager) StartProcess(command string, workingDir string, env map[string]string, restartOnFailure bool, maxRestarts int, keepAlive bool, timeout int, callback func(process *ProcessInfo)) (string, error) {
+func (pm *ProcessManager) StartProcess(command string, workingDir string, env map[string]string, restartOnFailure bool, maxRestarts int, keepAlive bool, timeout int, stdin bool, callback func(process *ProcessInfo)) (string, error) {
 	name := GenerateRandomName(8)
-	return pm.StartProcessWithName(command, workingDir, name, env, restartOnFailure, maxRestarts, keepAlive, timeout, callback)
+	return pm.StartProcessWithName(command, workingDir, name, env, restartOnFailure, maxRestarts, keepAlive, timeout, stdin, callback)
 }
 
-func (pm *ProcessManager) StartProcessWithName(command string, workingDir string, name string, env map[string]string, restartOnFailure bool, maxRestarts int, keepAlive bool, timeout int, callback func(process *ProcessInfo)) (string, error) {
+func (pm *ProcessManager) StartProcessWithName(command string, workingDir string, name string, env map[string]string, restartOnFailure bool, maxRestarts int, keepAlive bool, timeout int, stdin bool, callback func(process *ProcessInfo)) (string, error) {
 	// Always use shell to execute commands
 	// This ensures shell built-ins (cd, export, alias) work properly
 	// Use SHELL and SHELL_ARGS environment variables if set
@@ -342,6 +344,7 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 		MaxRestarts:      maxRestarts,
 		RestartCount:     0,
 		KeepAlive:        keepAlive,
+		Stdin:            stdin,
 		Timeout:          timeout,
 		LogFile:          combinedPath,
 		StdoutFile:       stdoutPath,
@@ -361,6 +364,14 @@ func (pm *ProcessManager) StartProcessWithName(command string, workingDir string
 	// So child survives sandbox-api restart without blocking
 	cmd.Stdout = stdoutFile
 	cmd.Stderr = stderrFile
+
+	if err := attachStdin(cmd, process); err != nil {
+		stdoutFile.Close()
+		stderrFile.Close()
+		os.Remove(stdoutPath)
+		os.Remove(stderrPath)
+		return "", err
+	}
 
 	// Start the process
 	if err := cmd.Start(); err != nil {
@@ -627,8 +638,8 @@ func (pm *ProcessManager) tailLogFiles(proc *ProcessInfo) {
 			// Drain all remaining data from both files before returning.
 			// Loop until both files return 0 bytes to handle data larger than the buffer.
 			for {
-				n1 := pm.readAndBroadcast(stdoutFile, stdoutBuf, proc, "stdout", combinedFile)
-				n2 := pm.readAndBroadcast(stderrFile, stderrBuf, proc, "stderr", combinedFile)
+				n1 := pm.drainStream(stdoutFile, stdoutBuf, proc, "stdout", combinedFile)
+				n2 := pm.drainStream(stderrFile, stderrBuf, proc, "stderr", combinedFile)
 				if n1 == 0 && n2 == 0 {
 					break
 				}
@@ -637,11 +648,39 @@ func (pm *ProcessManager) tailLogFiles(proc *ProcessInfo) {
 			close(proc.TailDone)
 			return
 		default:
-			pm.readAndBroadcast(stdoutFile, stdoutBuf, proc, "stdout", combinedFile)
-			pm.readAndBroadcast(stderrFile, stderrBuf, proc, "stderr", combinedFile)
+			pm.drainStream(stdoutFile, stdoutBuf, proc, "stdout", combinedFile)
+			pm.drainStream(stderrFile, stderrBuf, proc, "stderr", combinedFile)
 			time.Sleep(50 * time.Millisecond)
 		}
 	}
+}
+
+// drainStream reads one stream until it sits at a line boundary or has no more
+// data ready. The two streams are read in turns, one buffer at a time, so
+// without this a stderr line landed inside any stdout line longer than the
+// buffer: the text stream carried "stdout:<4KB>stderr:...\n<rest>" and no
+// line-oriented consumer could parse either half. A child that itself pauses
+// mid-line to write stderr can still interleave; that is its own doing.
+// Returns the number of bytes read.
+func (pm *ProcessManager) drainStream(file *os.File, buf []byte, proc *ProcessInfo, streamType string, combinedFile *os.File) int {
+	total := 0
+	for {
+		n := pm.readAndBroadcast(file, buf, proc, streamType, combinedFile)
+		total += n
+		if n == 0 || !proc.midLine(streamType) {
+			return total
+		}
+	}
+}
+
+// midLine reports whether the stream's last read ended part-way through a line.
+func (p *ProcessInfo) midLine(streamType string) bool {
+	p.logLock.RLock()
+	defer p.logLock.RUnlock()
+	if streamType == "stderr" {
+		return p.stderrMidLine
+	}
+	return p.stdoutMidLine
 }
 
 // readAndBroadcast reads from a file and broadcasts to log writers.
@@ -833,6 +872,12 @@ func (pm *ProcessManager) restartProcess(oldProcess *ProcessInfo, callback func(
 	oldProcess.stdoutMidLine = false
 	oldProcess.stderrMidLine = false
 	oldProcess.logLock.Unlock()
+
+	if err := attachStdin(cmd, oldProcess); err != nil {
+		stdoutFile.Close()
+		stderrFile.Close()
+		return "", err
+	}
 
 	// Start the process
 	if err := cmd.Start(); err != nil {

--- a/sandbox-api/src/handler/process/process.go
+++ b/sandbox-api/src/handler/process/process.go
@@ -768,22 +768,28 @@ func (pm *ProcessManager) tailLogFiles(proc *ProcessInfo) {
 	}
 }
 
-// drainStream reads one stream until it sits at a line boundary or has no more
-// data ready. The two streams are read in turns, one buffer at a time, so
-// without this a stderr line landed inside any stdout line longer than the
-// buffer: the text stream carried "stdout:<4KB>stderr:...\n<rest>" and no
-// line-oriented consumer could parse either half. A child that itself pauses
-// mid-line to write stderr can still interleave; that is its own doing.
-// Returns the number of bytes read.
+// maxDrainReads caps how many buffers drainStream takes from one stream in a
+// turn: 16 x 4 KiB. A line longer than that is not line-oriented output, and
+// the other stream must not starve behind it.
+const maxDrainReads = 16
+
+// drainStream reads one stream until it sits at a line boundary, has no more
+// data ready, or has used its turn. The two streams are read in turns, one
+// buffer at a time, so without this a stderr line landed inside any stdout
+// line longer than the buffer: the text stream carried
+// "stdout:<4KB>stderr:...\n<rest>" and no line-oriented consumer could parse
+// either half. A child that itself pauses mid-line to write stderr can still
+// interleave; that is its own doing. Returns the number of bytes read.
 func (pm *ProcessManager) drainStream(file *os.File, buf []byte, proc *ProcessInfo, streamType string, combinedFile *os.File) int {
 	total := 0
-	for {
+	for reads := 0; reads < maxDrainReads; reads++ {
 		n := pm.readAndBroadcast(file, buf, proc, streamType, combinedFile)
 		total += n
 		if n == 0 || !proc.midLine(streamType) {
-			return total
+			break
 		}
 	}
+	return total
 }
 
 // midLine reports whether the stream's last read ended part-way through a line.

--- a/sandbox-api/src/handler/process/process_test.go
+++ b/sandbox-api/src/handler/process/process_test.go
@@ -950,7 +950,7 @@ func TestSuspendedRestartsLeaveAFailedProcessDown(t *testing.T) {
 	defer allow()
 
 	done := make(chan *ProcessInfo, 1)
-	pid, err := pm.StartProcess(`echo failing; exit 1`, "", nil, true, -1, false, 0, func(p *ProcessInfo) {
+	pid, err := pm.StartProcess(`echo failing; exit 1`, "", nil, true, -1, false, 0, false, func(p *ProcessInfo) {
 		done <- p
 	})
 	if err != nil {
@@ -978,7 +978,7 @@ func TestRestartsSuspendedDuringTheDelayLeaveTheProcessDown(t *testing.T) {
 	pm := GetProcessManager()
 
 	done := make(chan *ProcessInfo, 1)
-	pid, err := pm.StartProcess(`echo failing; exit 1`, "", nil, true, -1, false, 0, func(p *ProcessInfo) {
+	pid, err := pm.StartProcess(`echo failing; exit 1`, "", nil, true, -1, false, 0, false, func(p *ProcessInfo) {
 		done <- p
 	})
 	if err != nil {

--- a/sandbox-api/src/handler/process/process_test.go
+++ b/sandbox-api/src/handler/process/process_test.go
@@ -30,7 +30,7 @@ func TestProcessManagerIntegrationWithPID(t *testing.T) {
 
 	// Test starting a long-running process
 	t.Run("StartLongRunningProcess", func(t *testing.T) {
-		sleepPID, err := pm.StartProcess("sleep 5", "", nil, false, 0, false, 0, func(process *ProcessInfo) {
+		sleepPID, err := pm.StartProcess("sleep 5", "", nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			t.Logf("Process: %+v", process.stderr)
 		})
 		if err != nil {
@@ -79,7 +79,7 @@ func TestProcessManagerIntegrationWithPID(t *testing.T) {
 	t.Run("ProcessWithOutput", func(t *testing.T) {
 		expectedOutput := "Hello, Process Manager!"
 		done := make(chan struct{})
-		echoPID, err := pm.StartProcess("echo '"+expectedOutput+"'", "", nil, false, 0, false, 0, func(process *ProcessInfo) {
+		echoPID, err := pm.StartProcess("echo '"+expectedOutput+"'", "", nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			close(done)
 		})
 		if err != nil {
@@ -120,7 +120,7 @@ func TestProcessManagerIntegrationWithPID(t *testing.T) {
 	// Test process with working directory
 	t.Run("ProcessWithWorkingDirectory", func(t *testing.T) {
 		done := make(chan struct{})
-		lsPID, err := pm.StartProcess("ls -la", "/tmp", nil, false, 0, false, 0, func(process *ProcessInfo) {
+		lsPID, err := pm.StartProcess("ls -la", "/tmp", nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			close(done)
 		})
 		if err != nil {
@@ -167,7 +167,7 @@ func TestProcessManagerIntegrationWithPID(t *testing.T) {
 	// Test list processes functionality
 	t.Run("ListProcesses", func(t *testing.T) {
 		// Start a new process for this test
-		testPID, err := pm.StartProcess("sleep 1", "", nil, false, 0, false, 0, func(process *ProcessInfo) {
+		testPID, err := pm.StartProcess("sleep 1", "", nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			t.Logf("Process: %+v", process.stderr)
 		})
 		if err != nil {
@@ -204,7 +204,7 @@ func TestProcessManagerIntegrationWithName(t *testing.T) {
 	// Test starting a long-running process
 	t.Run("StartLongRunningProcess", func(t *testing.T) {
 		name := "sleep-process"
-		_, err := pm.StartProcessWithName("sleep 5", "", name, nil, false, 0, false, 0, func(process *ProcessInfo) {
+		_, err := pm.StartProcessWithName("sleep 5", "", name, nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			t.Logf("Process: %+v", process.stderr)
 		})
 		if err != nil {
@@ -253,7 +253,7 @@ func TestProcessManagerIntegrationWithName(t *testing.T) {
 	t.Run("ProcessWithOutput", func(t *testing.T) {
 		expectedOutput := "Hello, Process Manager!"
 		name := "echo-process"
-		_, err := pm.StartProcessWithName("echo '"+expectedOutput+"'", "", name, nil, false, 0, false, 0, func(process *ProcessInfo) {
+		_, err := pm.StartProcessWithName("echo '"+expectedOutput+"'", "", name, nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			t.Logf("Process: %+v", process.stderr)
 		})
 		if err != nil {
@@ -294,7 +294,7 @@ func TestProcessManagerIntegrationWithName(t *testing.T) {
 	// Test process with working directory
 	t.Run("ProcessWithWorkingDirectory", func(t *testing.T) {
 		name := "ls-process"
-		_, err := pm.StartProcessWithName("ls -la", "", name, nil, false, 0, false, 0, func(process *ProcessInfo) {
+		_, err := pm.StartProcessWithName("ls -la", "", name, nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			t.Logf("Process: %+v", process.stderr)
 		})
 		if err != nil {
@@ -342,7 +342,7 @@ func TestProcessManagerIntegrationWithName(t *testing.T) {
 	t.Run("ListProcesses", func(t *testing.T) {
 		// Start a new process for this test
 		name := "test-process"
-		_, err := pm.StartProcessWithName("sleep 1", "", name, nil, false, 0, false, 0, func(process *ProcessInfo) {
+		_, err := pm.StartProcessWithName("sleep 1", "", name, nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			t.Logf("Process: %+v", process.stderr)
 		})
 		if err != nil {
@@ -391,7 +391,7 @@ func TestEnvironmentVariableHandling(t *testing.T) {
 			t.Logf("Test iteration %d", i+1)
 
 			// Use printenv to check all environment variables
-			pid, err := pm.StartProcess("printenv", "", env, false, 0, false, 0, func(process *ProcessInfo) {
+			pid, err := pm.StartProcess("printenv", "", env, false, 0, false, 0, false, func(process *ProcessInfo) {
 				t.Logf("Process completed: %s", process.PID)
 			})
 			if err != nil {
@@ -462,7 +462,7 @@ func TestEnvironmentVariableHandling(t *testing.T) {
 		// Test with empty environment map - should inherit system environment
 		env := map[string]string{}
 
-		pid, err := pm.StartProcess("printenv PATH", "", env, false, 0, false, 0, func(process *ProcessInfo) {
+		pid, err := pm.StartProcess("printenv PATH", "", env, false, 0, false, 0, false, func(process *ProcessInfo) {
 			t.Logf("Process completed: %s", process.PID)
 		})
 		if err != nil {
@@ -488,7 +488,7 @@ func TestEnvironmentVariableHandling(t *testing.T) {
 		// Test with nil environment map - should inherit system environment
 		var env map[string]string = nil
 
-		pid, err := pm.StartProcess("printenv PATH", "", env, false, 0, false, 0, func(process *ProcessInfo) {
+		pid, err := pm.StartProcess("printenv PATH", "", env, false, 0, false, 0, false, func(process *ProcessInfo) {
 			t.Logf("Process completed: %s", process.PID)
 		})
 		if err != nil {
@@ -522,7 +522,7 @@ func TestProcessRestartOnFailure(t *testing.T) {
 
 		completionChan := make(chan *ProcessInfo, 1)
 
-		pid, err := pm.StartProcess(command, "", nil, true, 3, false, 0, func(process *ProcessInfo) {
+		pid, err := pm.StartProcess(command, "", nil, true, 3, false, 0, false, func(process *ProcessInfo) {
 			completionChan <- process
 		})
 		if err != nil {
@@ -576,7 +576,7 @@ func TestProcessRestartOnFailure(t *testing.T) {
 
 		completionChan := make(chan *ProcessInfo, 1)
 
-		pid, err := pm.StartProcess(command, "", nil, true, 2, false, 0, func(process *ProcessInfo) {
+		pid, err := pm.StartProcess(command, "", nil, true, 2, false, 0, false, func(process *ProcessInfo) {
 			completionChan <- process
 		})
 		if err != nil {
@@ -633,7 +633,7 @@ func TestProcessRestartOnFailure(t *testing.T) {
 
 		completionChan := make(chan *ProcessInfo, 1)
 
-		pid, err := pm.StartProcess(command, "", env, true, 3, false, 0, func(process *ProcessInfo) {
+		pid, err := pm.StartProcess(command, "", env, true, 3, false, 0, false, func(process *ProcessInfo) {
 			completionChan <- process
 		})
 		if err != nil {
@@ -680,7 +680,7 @@ func TestProcessRestartOnFailure(t *testing.T) {
 
 		completionChan := make(chan *ProcessInfo, 1)
 
-		pid, err := pm.StartProcess(command, "", nil, true, -1, false, 0, func(process *ProcessInfo) {
+		pid, err := pm.StartProcess(command, "", nil, true, -1, false, 0, false, func(process *ProcessInfo) {
 			completionChan <- process
 		})
 		if err != nil {
@@ -719,7 +719,7 @@ func TestProcessRestartOnFailure(t *testing.T) {
 
 		completionChan := make(chan *ProcessInfo, 1)
 
-		pid, err := pm.StartProcess(command, "", nil, true, 3, false, 0, func(process *ProcessInfo) {
+		pid, err := pm.StartProcess(command, "", nil, true, 3, false, 0, false, func(process *ProcessInfo) {
 			completionChan <- process
 		})
 		if err != nil {
@@ -792,7 +792,7 @@ func TestLargeOutputStreaming(t *testing.T) {
 
 		completionChan := make(chan *ProcessInfo, 1)
 
-		pid, err := pm.StartProcess(command, "", nil, false, 0, false, 0, func(process *ProcessInfo) {
+		pid, err := pm.StartProcess(command, "", nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			completionChan <- process
 		})
 		if err != nil {
@@ -846,7 +846,7 @@ func TestLargeOutputStreaming(t *testing.T) {
 
 		completionChan := make(chan *ProcessInfo, 1)
 
-		pid, err := pm.StartProcess(command, "", nil, false, 0, false, 0, func(process *ProcessInfo) {
+		pid, err := pm.StartProcess(command, "", nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			completionChan <- process
 		})
 		if err != nil {
@@ -892,7 +892,7 @@ func TestLargeOutputStreaming(t *testing.T) {
 
 		completionChan := make(chan *ProcessInfo, 1)
 
-		pid, err := pm.StartProcess(command, "", nil, false, 0, false, 0, func(process *ProcessInfo) {
+		pid, err := pm.StartProcess(command, "", nil, false, 0, false, 0, false, func(process *ProcessInfo) {
 			completionChan <- process
 		})
 		if err != nil {

--- a/sandbox-api/src/handler/process/service.go
+++ b/sandbox-api/src/handler/process/service.go
@@ -23,6 +23,7 @@ func (pm *ProcessManager) ExecuteProcess(
 	restartOnFailure bool,
 	maxRestarts int,
 	keepAlive bool,
+	stdin bool,
 ) (*ProcessInfo, error) {
 	portCh := make(chan int)
 	completionCh := make(chan string)
@@ -78,9 +79,9 @@ func (pm *ProcessManager) ExecuteProcess(
 	var pid string
 	var err error
 	if name != "" {
-		pid, err = pm.StartProcessWithName(command, workingDir, name, env, restartOnFailure, maxRestarts, keepAlive, timeout, callback)
+		pid, err = pm.StartProcessWithName(command, workingDir, name, env, restartOnFailure, maxRestarts, keepAlive, timeout, stdin, callback)
 	} else {
-		pid, err = pm.StartProcess(command, workingDir, env, restartOnFailure, maxRestarts, keepAlive, timeout, callback)
+		pid, err = pm.StartProcess(command, workingDir, env, restartOnFailure, maxRestarts, keepAlive, timeout, stdin, callback)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to start process: %w", err)

--- a/sandbox-api/src/handler/process/state.go
+++ b/sandbox-api/src/handler/process/state.go
@@ -48,6 +48,7 @@ type ProcessState struct {
 	StderrBytes      int                     `json:"stderrBytes,omitempty"`
 	LogsBytes        int                     `json:"logsBytes,omitempty"`
 	RestartOnFailure bool                    `json:"restartOnFailure"`
+	Stdin            bool                    `json:"stdin,omitempty"` // Kept so a reattached process reports "stdin closed" rather than "not enabled"
 	MaxRestarts      int                     `json:"maxRestarts"`
 	RestartCount     int                     `json:"restartCount"`
 	Env              map[string]string       `json:"env,omitempty"` // Custom env vars provided at start, reused on restart-on-failure
@@ -120,6 +121,7 @@ func (pm *ProcessManager) SaveState() error {
 			StderrBytes:      stderrBytes,
 			LogsBytes:        logsBytes,
 			RestartOnFailure: proc.RestartOnFailure,
+			Stdin:            proc.Stdin,
 			MaxRestarts:      proc.MaxRestarts,
 			RestartCount:     proc.RestartCount,
 			Env:              proc.Env,
@@ -230,6 +232,7 @@ func (pm *ProcessManager) LoadState() error {
 			StdoutFile:       procState.StdoutFile,
 			StderrFile:       procState.StderrFile,
 			RestartOnFailure: procState.RestartOnFailure,
+			Stdin:            procState.Stdin,
 			MaxRestarts:      procState.MaxRestarts,
 			RestartCount:     procState.RestartCount,
 			Env:              procState.Env,

--- a/sandbox-api/src/handler/process/stdin.go
+++ b/sandbox-api/src/handler/process/stdin.go
@@ -4,17 +4,29 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"sync"
+	"time"
 )
 
 var (
 	// ErrStdinNotEnabled is returned when writing to a process started without stdin: true.
 	ErrStdinNotEnabled = errors.New("process was started without stdin; start it with \"stdin\": true")
-	// ErrStdinClosed is returned once stdin has been closed, or after a sandbox-api
-	// restart: the pipe lived in the previous sandbox-api process and died with it.
+	// ErrStdinClosed is returned once stdin has been closed, the process has
+	// exited, or after a sandbox-api restart: the pipe lived in the previous
+	// sandbox-api process and died with it.
 	ErrStdinClosed = errors.New("stdin is closed; restart the process to get a new one")
+	// ErrStdinStalled is returned when the child stops reading and the pipe
+	// buffer stays full for stdinWriteTimeout. Part of the body may have been
+	// written; the caller decides whether the stream is still usable.
+	ErrStdinStalled = errors.New("process is not reading its stdin")
 )
+
+// stdinWriteTimeout bounds one write, and with it the time the pipe lock is
+// held: a child that stops reading must not pin an HTTP goroutine and every
+// later writer for good. A var so tests can shorten it.
+var stdinWriteTimeout = 10 * time.Second
 
 // stdinPipe is the parent's write end of a process's stdin. A plain pipe, not a
 // FIFO on disk, so it does not survive a sandbox-api restart: the child sees EOF,
@@ -54,10 +66,23 @@ func (pm *ProcessManager) WriteStdin(identifier string, data []byte) error {
 	if p.stdin.w == nil {
 		return ErrStdinClosed
 	}
-	if _, err := p.stdin.w.Write(data); err != nil {
+	if f, ok := p.stdin.w.(*os.File); ok {
+		_ = f.SetWriteDeadline(time.Now().Add(stdinWriteTimeout))
+		defer f.SetWriteDeadline(time.Time{})
+	}
+	_, err = p.stdin.w.Write(data)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, os.ErrClosed):
+		// exec.Cmd.Wait closed the pipe when the child exited.
+		p.stdin.w = nil
+		return ErrStdinClosed
+	case errors.Is(err, os.ErrDeadlineExceeded):
+		return ErrStdinStalled
+	default:
 		return fmt.Errorf("failed to write to stdin: %w", err)
 	}
-	return nil
 }
 
 // CloseStdin sends EOF to the process. Idempotent.
@@ -73,6 +98,10 @@ func (pm *ProcessManager) CloseStdin(identifier string) error {
 	}
 	err = p.stdin.w.Close()
 	p.stdin.w = nil
+	if errors.Is(err, os.ErrClosed) {
+		// Already closed by exec.Cmd.Wait when the child exited: still EOF.
+		return nil
+	}
 	return err
 }
 

--- a/sandbox-api/src/handler/process/stdin.go
+++ b/sandbox-api/src/handler/process/stdin.go
@@ -1,0 +1,88 @@
+package process
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+)
+
+var (
+	// ErrStdinNotEnabled is returned when writing to a process started without stdin: true.
+	ErrStdinNotEnabled = errors.New("process was started without stdin; start it with \"stdin\": true")
+	// ErrStdinClosed is returned once stdin has been closed, or after a sandbox-api
+	// restart: the pipe lived in the previous sandbox-api process and died with it.
+	ErrStdinClosed = errors.New("stdin is closed; restart the process to get a new one")
+)
+
+// stdinPipe is the parent's write end of a process's stdin. A plain pipe, not a
+// FIFO on disk, so it does not survive a sandbox-api restart: the child sees EOF,
+// which is the documented shutdown path for stdio protocols such as MCP.
+// ponytail: swap for a mkfifo next to the log files if stdin must outlive sandbox-api.
+type stdinPipe struct {
+	mu sync.Mutex
+	w  io.WriteCloser
+}
+
+// attachStdin gives cmd a stdin pipe when the process asked for one. Called on
+// every run, so a restart-on-failure gets a fresh pipe; exec.Cmd.Wait closes the
+// previous one when the old run exits.
+func attachStdin(cmd *exec.Cmd, p *ProcessInfo) error {
+	if !p.Stdin {
+		return nil
+	}
+	w, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+	p.stdin.mu.Lock()
+	p.stdin.w = w
+	p.stdin.mu.Unlock()
+	return nil
+}
+
+// WriteStdin writes data verbatim to the process's stdin. The whole body goes
+// out under one lock, so concurrent writers never interleave inside a message.
+func (pm *ProcessManager) WriteStdin(identifier string, data []byte) error {
+	p, err := pm.stdinTarget(identifier)
+	if err != nil {
+		return err
+	}
+	p.stdin.mu.Lock()
+	defer p.stdin.mu.Unlock()
+	if p.stdin.w == nil {
+		return ErrStdinClosed
+	}
+	if _, err := p.stdin.w.Write(data); err != nil {
+		return fmt.Errorf("failed to write to stdin: %w", err)
+	}
+	return nil
+}
+
+// CloseStdin sends EOF to the process. Idempotent.
+func (pm *ProcessManager) CloseStdin(identifier string) error {
+	p, err := pm.stdinTarget(identifier)
+	if err != nil {
+		return err
+	}
+	p.stdin.mu.Lock()
+	defer p.stdin.mu.Unlock()
+	if p.stdin.w == nil {
+		return nil
+	}
+	err = p.stdin.w.Close()
+	p.stdin.w = nil
+	return err
+}
+
+func (pm *ProcessManager) stdinTarget(identifier string) (*ProcessInfo, error) {
+	p, exists := pm.GetProcessByIdentifier(identifier)
+	if !exists {
+		return nil, fmt.Errorf("process with identifier %s not found", identifier)
+	}
+	if !p.Stdin {
+		return nil, ErrStdinNotEnabled
+	}
+	return p, nil
+}

--- a/sandbox-api/src/handler/process/stdin_test.go
+++ b/sandbox-api/src/handler/process/stdin_test.go
@@ -1,0 +1,113 @@
+package process
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// noop stands in for the completion callback, which the manager requires.
+func noop(*ProcessInfo) {}
+
+func newStdinTestManager(t *testing.T) *ProcessManager {
+	t.Helper()
+	original := ProcessLogDir
+	ProcessLogDir = t.TempDir()
+	t.Cleanup(func() { ProcessLogDir = original })
+	return NewProcessManager()
+}
+
+// waitFor polls cond until it holds or the deadline passes.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func stdoutContains(pm *ProcessManager, pid, needle string) func() bool {
+	return func() bool {
+		logs, err := pm.GetProcessOutput(pid)
+		return err == nil && strings.Contains(logs.Stdout, needle)
+	}
+}
+
+// A write reaches the child verbatim, and closing stdin ends it: the two halves
+// of driving a stdio protocol.
+func TestStdinRoundTripThenEOF(t *testing.T) {
+	pm := newStdinTestManager(t)
+	pid, err := pm.StartProcess("cat", "", nil, false, 0, false, 0, true, noop)
+	if err != nil {
+		t.Fatalf("starting cat: %v", err)
+	}
+
+	if err := pm.WriteStdin(pid, []byte(`{"jsonrpc":"2.0","id":1}`+"\n")); err != nil {
+		t.Fatalf("writing stdin: %v", err)
+	}
+	waitFor(t, "echoed line", stdoutContains(pm, pid, `{"jsonrpc":"2.0","id":1}`))
+
+	if err := pm.CloseStdin(pid); err != nil {
+		t.Fatalf("closing stdin: %v", err)
+	}
+	waitFor(t, "cat to exit on EOF", func() bool {
+		p, _ := pm.GetProcessByIdentifier(pid)
+		return p.Status == StatusCompleted
+	})
+
+	// Closing twice is a no-op, writing afterwards is a clear error.
+	if err := pm.CloseStdin(pid); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+	if err := pm.WriteStdin(pid, []byte("x\n")); !errors.Is(err, ErrStdinClosed) {
+		t.Fatalf("write after close: got %v, want ErrStdinClosed", err)
+	}
+}
+
+func TestStdinNotEnabled(t *testing.T) {
+	pm := newStdinTestManager(t)
+	pid, err := pm.StartProcess("sleep 5", "", nil, false, 0, false, 0, false, noop)
+	if err != nil {
+		t.Fatalf("starting sleep: %v", err)
+	}
+	t.Cleanup(func() { _ = pm.KillProcess(pid) })
+
+	if err := pm.WriteStdin(pid, []byte("x\n")); !errors.Is(err, ErrStdinNotEnabled) {
+		t.Fatalf("got %v, want ErrStdinNotEnabled", err)
+	}
+	if err := pm.CloseStdin(pid); !errors.Is(err, ErrStdinNotEnabled) {
+		t.Fatalf("close: got %v, want ErrStdinNotEnabled", err)
+	}
+	if err := pm.WriteStdin("no-such-process", nil); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unknown process: got %v", err)
+	}
+}
+
+// A restart-on-failure run is a new child, so it needs a new pipe: the old one
+// was closed by Wait when the failed run exited.
+func TestStdinFreshPipeAfterRestart(t *testing.T) {
+	pm := newStdinTestManager(t)
+	pid, err := pm.StartProcess(`sh -c 'read l; echo "got:$l"; exit 1'`, "", nil, true, 1, false, 0, true, noop)
+	if err != nil {
+		t.Fatalf("starting process: %v", err)
+	}
+
+	if err := pm.WriteStdin(pid, []byte("one\n")); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	waitFor(t, "first echo", stdoutContains(pm, pid, "got:one"))
+	waitFor(t, "restarted run", func() bool {
+		p, _ := pm.GetProcessByIdentifier(pid)
+		return p.RestartCount == 1 && p.Status == StatusRunning
+	})
+
+	if err := pm.WriteStdin(pid, []byte("two\n")); err != nil {
+		t.Fatalf("write after restart: %v", err)
+	}
+	waitFor(t, "second echo", stdoutContains(pm, pid, "got:two"))
+}

--- a/sandbox-api/src/handler/process/stdin_test.go
+++ b/sandbox-api/src/handler/process/stdin_test.go
@@ -111,3 +111,51 @@ func TestStdinFreshPipeAfterRestart(t *testing.T) {
 	}
 	waitFor(t, "second echo", stdoutContains(pm, pid, "got:two"))
 }
+
+// Once the child has exited on its own, exec.Cmd.Wait has closed the pipe:
+// writes must say "closed", not fail as a server error, and close stays a no-op.
+func TestStdinAfterNaturalExit(t *testing.T) {
+	pm := newStdinTestManager(t)
+	pid, err := pm.StartProcess("true", "", nil, false, 0, false, 0, true, noop)
+	if err != nil {
+		t.Fatalf("starting process: %v", err)
+	}
+	waitFor(t, "process to exit", func() bool {
+		p, _ := pm.GetProcessByIdentifier(pid)
+		return p.Status == StatusCompleted
+	})
+	if err := pm.WriteStdin(pid, []byte("late\n")); !errors.Is(err, ErrStdinClosed) {
+		t.Fatalf("write after exit: got %v, want ErrStdinClosed", err)
+	}
+	if err := pm.CloseStdin(pid); err != nil {
+		t.Fatalf("close after exit: %v", err)
+	}
+}
+
+// A child that never reads must not pin the writer forever: the write gives up
+// after stdinWriteTimeout and the lock is free for the close that follows.
+func TestStdinStalledWriteTimesOut(t *testing.T) {
+	pm := newStdinTestManager(t)
+	original := stdinWriteTimeout
+	stdinWriteTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { stdinWriteTimeout = original })
+
+	pid, err := pm.StartProcess("sleep 30", "", nil, false, 0, false, 0, true, noop)
+	if err != nil {
+		t.Fatalf("starting process: %v", err)
+	}
+	t.Cleanup(func() { _ = pm.KillProcess(pid) })
+
+	// Well past the kernel pipe buffer, into a reader that never drains it.
+	start := time.Now()
+	err = pm.WriteStdin(pid, make([]byte, 1<<20))
+	if !errors.Is(err, ErrStdinStalled) {
+		t.Fatalf("got %v, want ErrStdinStalled", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("write blocked %s, deadline not applied", elapsed)
+	}
+	if err := pm.CloseStdin(pid); err != nil {
+		t.Fatalf("close after stall: %v", err)
+	}
+}

--- a/sandbox-api/src/handler/process_keepalive_test.go
+++ b/sandbox-api/src/handler/process_keepalive_test.go
@@ -20,13 +20,13 @@ func TestExecuteProcessKeepAliveDisabled(t *testing.T) {
 	t.Setenv(blaxel.EnvDisableKeepAlive, "true")
 	h := NewProcessHandler()
 
-	_, err := h.ExecuteProcess("echo keepalive", "", "", nil, true, 5, nil, false, 0, true)
+	_, err := h.ExecuteProcess("echo keepalive", "", "", nil, true, 5, nil, false, 0, true, false)
 	if !errors.Is(err, ErrKeepAliveDisabled) {
 		t.Fatalf("ExecuteProcess with keepAlive=true should return ErrKeepAliveDisabled, got %v", err)
 	}
 
 	// keepAlive=false still works
-	resp, err := h.ExecuteProcess("echo keepalive", "", "", nil, true, 5, nil, false, 0, false)
+	resp, err := h.ExecuteProcess("echo keepalive", "", "", nil, true, 5, nil, false, 0, false, false)
 	if err != nil {
 		t.Fatalf("ExecuteProcess with keepAlive=false should succeed, got %v", err)
 	}
@@ -40,7 +40,7 @@ func TestExecuteProcessKeepAliveEnabledByDefault(t *testing.T) {
 	t.Setenv(blaxel.EnvDisableKeepAlive, "")
 	h := NewProcessHandler()
 
-	resp, err := h.ExecuteProcess("echo keepalive", "", "", nil, true, 5, nil, false, 0, true)
+	resp, err := h.ExecuteProcess("echo keepalive", "", "", nil, true, 5, nil, false, 0, true, false)
 	if err != nil {
 		t.Fatalf("ExecuteProcess with keepAlive=true should succeed when the flag is unset, got %v", err)
 	}

--- a/sandbox-api/src/mcp/process.go
+++ b/sandbox-api/src/mcp/process.go
@@ -143,6 +143,7 @@ func (s *Server) registerProcessTools() error {
 			restartOnFailure,
 			maxRestarts,
 			keepAlive,
+			false, // stdin: no MCP tool writes to it yet
 		)
 
 		// Check if this is a timeout error due to the capped timeout (CloudFront workaround)


### PR DESCRIPTION
**What this is:** a way to write to a running process's stdin over HTTP, so a stdio MCP server can run inside a sandbox and be driven from outside.

**The problem:** `POST /process` gives stdout but no way to send input afterwards. The only stdin on the box is the terminal PTY, which adds echo and escape codes that corrupt line-based protocols like JSON-RPC. A customer asked for exactly this to point their MCP stdio transport at Blaxel.

**What it changes:**
- `"stdin": true` on `POST /process` opens a stdin pipe. `POST /process/{name}/stdin` writes the raw body verbatim, `DELETE /process/{name}/stdin` sends EOF. A process without stdin, or whose pipe is gone, gets a clear 409.
- The pipe does not survive a sandbox-api restart: the process sees EOF and shuts down, the client restarts it. Documented in `sandbox-api/docs/STDIN.md`. Restart-on-failure gets a fresh pipe per run.
- Fixes an existing streaming bug found while testing: a stderr line could land in the middle of a stdout line longer than 4 KiB, breaking any long JSON response for a client reading the log stream. The tailer now finishes the current line before switching streams.

**How it was checked:** unit tests for write, EOF, restart and the splicing fix, plus integration tests against the dev image including a real `@modelcontextprotocol/server-filesystem` driven end to end (initialize, tools/list, shutdown on EOF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/blaxel-ai/sandbox/pull/318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->